### PR TITLE
refactor: encode at the wire, decode at stdCollectionOptions

### DIFF
--- a/std-toolkit/cache/src/__tests__/idb-cache-single-item.test.ts
+++ b/std-toolkit/cache/src/__tests__/idb-cache-single-item.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 const itEffect = <A, E>(name: string, fn: () => Effect.Effect<A, E, never>) =>
   it(name, () => Effect.runPromise(fn()));
 import { Effect, Option, Schema } from 'effect';
-import { SingleEntityESchema } from '@std-toolkit/eschema';
+import { SingleEntityESchema, type ESchemaEncoded } from '@std-toolkit/eschema';
 import type { EntityType } from '@std-toolkit/core';
 import { IDBCacheSingleItem } from '../idb/idb-cache-single-item.js';
 
@@ -19,9 +19,9 @@ const ConfigSchema = SingleEntityESchema.make('Config', {
 function makeConfigEntity(
   theme: string,
   locale: string,
-): EntityType<typeof ConfigSchema.Type> {
+): EntityType<ESchemaEncoded<typeof ConfigSchema>> {
   return {
-    value: { theme, locale },
+    value: { theme, locale, _v: 'v1' as const },
     meta: {
       _e: ConfigSchema.name,
       _v: ConfigSchema.latestVersion,

--- a/std-toolkit/cache/src/__tests__/idb-cache.test.ts
+++ b/std-toolkit/cache/src/__tests__/idb-cache.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 const itEffect = <A, E>(name: string, fn: () => Effect.Effect<A, E, never>) =>
   it(name, () => Effect.runPromise(fn()));
 import { Effect, Option, Schema } from 'effect';
-import { EntityESchema } from '@std-toolkit/eschema';
+import { EntityESchema, type ESchemaEncoded } from '@std-toolkit/eschema';
 import type { EntityType } from '@std-toolkit/core';
 import { IDBCacheEntity } from '../idb/idb-cache-entity.js';
 import { serializePartition } from '../idb/utils.js';
@@ -26,9 +26,9 @@ function makeUserEntity(
   id: string,
   name: string,
   email: string,
-): EntityType<typeof UserSchema.Type> {
+): EntityType<ESchemaEncoded<typeof UserSchema>> {
   return {
-    value: { id, name, email },
+    value: { id, name, email, _v: 'v1' as const },
     meta: {
       _e: UserSchema.name,
       _v: UserSchema.latestVersion,
@@ -42,9 +42,9 @@ function makePostEntity(
   id: string,
   title: string,
   content: string,
-): EntityType<typeof PostSchema.Type> {
+): EntityType<ESchemaEncoded<typeof PostSchema>> {
   return {
-    value: { id, title, content },
+    value: { id, title, content, _v: 'v1' as const },
     meta: {
       _e: PostSchema.name,
       _v: PostSchema.latestVersion,
@@ -272,15 +272,30 @@ describe('IDBCacheEntity', () => {
       });
 
       yield* users.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-001', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-2', name: 'Bob', email: 'bob@example.com' },
+        value: {
+          id: 'user-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-003', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-3', name: 'Charlie', email: 'charlie@example.com' },
+        value: {
+          id: 'user-3',
+          name: 'Charlie',
+          email: 'charlie@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-002', _d: false },
       });
 
@@ -301,15 +316,30 @@ describe('IDBCacheEntity', () => {
       });
 
       yield* users.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-002', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-2', name: 'Bob', email: 'bob@example.com' },
+        value: {
+          id: 'user-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-001', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-3', name: 'Charlie', email: 'charlie@example.com' },
+        value: {
+          id: 'user-3',
+          name: 'Charlie',
+          email: 'charlie@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-003', _d: false },
       });
 
@@ -359,11 +389,21 @@ describe('IDBCacheEntity', () => {
       });
 
       yield* users.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-100', _d: false },
       });
       yield* posts.put({
-        value: { id: 'post-1', title: 'Hello', content: 'World' },
+        value: {
+          id: 'post-1',
+          title: 'Hello',
+          content: 'World',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'Post', _v: 'v1', _u: 'uid-200', _d: false },
       });
 
@@ -534,15 +574,30 @@ describe('IDBCacheEntity', () => {
       });
 
       yield* tenantAUsers.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@a.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@a.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-001', _d: false },
       });
       yield* tenantAUsers.put({
-        value: { id: 'user-2', name: 'Bob', email: 'bob@a.com' },
+        value: {
+          id: 'user-2',
+          name: 'Bob',
+          email: 'bob@a.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-003', _d: false },
       });
       yield* tenantBUsers.put({
-        value: { id: 'user-3', name: 'Charlie', email: 'charlie@b.com' },
+        value: {
+          id: 'user-3',
+          name: 'Charlie',
+          email: 'charlie@b.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-002', _d: false },
       });
 

--- a/std-toolkit/cache/src/__tests__/memory-cache.test.ts
+++ b/std-toolkit/cache/src/__tests__/memory-cache.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 const itEffect = <A, E>(name: string, fn: () => Effect.Effect<A, E, never>) =>
   it(name, () => Effect.runPromise(fn()));
 import { Effect, Option, Schema } from 'effect';
-import { EntityESchema } from '@std-toolkit/eschema';
+import { EntityESchema, type ESchemaEncoded } from '@std-toolkit/eschema';
 import type { EntityType } from '@std-toolkit/core';
 import { MemoryCacheEntity } from '../memory/memory-cache-entity.js';
 
@@ -16,9 +16,9 @@ function makeUserEntity(
   id: string,
   name: string,
   email: string,
-): EntityType<typeof UserSchema.Type> {
+): EntityType<ESchemaEncoded<typeof UserSchema>> {
   return {
-    value: { id, name, email },
+    value: { id, name, email, _v: 'v1' as const },
     meta: {
       _e: UserSchema.name,
       _v: UserSchema.latestVersion,
@@ -142,15 +142,30 @@ describe('MemoryCacheEntity', () => {
       const users = yield* MemoryCacheEntity.make({ eschema: UserSchema });
 
       yield* users.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-001', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-2', name: 'Bob', email: 'bob@example.com' },
+        value: {
+          id: 'user-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-003', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-3', name: 'Charlie', email: 'charlie@example.com' },
+        value: {
+          id: 'user-3',
+          name: 'Charlie',
+          email: 'charlie@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-002', _d: false },
       });
 
@@ -168,15 +183,30 @@ describe('MemoryCacheEntity', () => {
       const users = yield* MemoryCacheEntity.make({ eschema: UserSchema });
 
       yield* users.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-002', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-2', name: 'Bob', email: 'bob@example.com' },
+        value: {
+          id: 'user-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-001', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-3', name: 'Charlie', email: 'charlie@example.com' },
+        value: {
+          id: 'user-3',
+          name: 'Charlie',
+          email: 'charlie@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-003', _d: false },
       });
 
@@ -212,15 +242,30 @@ describe('MemoryCacheEntity', () => {
       const users = yield* MemoryCacheEntity.make({ eschema: UserSchema });
 
       yield* users.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-001', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-2', name: 'Bob', email: 'bob@example.com' },
+        value: {
+          id: 'user-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-003', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-3', name: 'Charlie', email: 'charlie@example.com' },
+        value: {
+          id: 'user-3',
+          name: 'Charlie',
+          email: 'charlie@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-002', _d: false },
       });
 
@@ -240,11 +285,21 @@ describe('MemoryCacheEntity', () => {
       const users = yield* MemoryCacheEntity.make({ eschema: UserSchema });
 
       yield* users.put({
-        value: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+        value: {
+          id: 'user-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-003', _d: false },
       });
       yield* users.put({
-        value: { id: 'user-2', name: 'Bob', email: 'bob@example.com' },
+        value: {
+          id: 'user-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          _v: 'v1' as const,
+        },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-002', _d: false },
       });
 
@@ -253,6 +308,7 @@ describe('MemoryCacheEntity', () => {
           id: 'user-1',
           name: 'Alice Updated',
           email: 'alice@example.com',
+          _v: 'v1' as const,
         },
         meta: { _e: 'User', _v: 'v1', _u: 'uid-001', _d: false },
       });

--- a/std-toolkit/cache/src/cache-entity.ts
+++ b/std-toolkit/cache/src/cache-entity.ts
@@ -3,11 +3,22 @@ import type { Effect, Option } from 'effect';
 import type { CacheError } from './error.js';
 import { AnyEntityESchema } from '@std-toolkit/eschema';
 
+/**
+ * Subset of an `EntityESchema` that the cache implementations rely on:
+ * `name` and `idField` for partitioning and key derivation, plus the
+ * `Encoded` shape (cache stores the JSON-safe encoded form).
+ */
 export type CacheSchemaType = Pick<
   AnyEntityESchema,
-  'name' | 'idField' | 'Type'
+  'name' | 'idField' | 'Type' | 'Encoded'
 >;
 
+/**
+ * Cache contract — `T` is the **encoded** shape of the entity
+ * (`ESchemaEncoded<S>`). Cache rows are JSON-safe so they can persist
+ * across reloads (IDB structured clone, memory) without losing transform
+ * fidelity. Decoding happens at the collection boundary, not here.
+ */
 export interface CacheEntity<T> {
   put(item: EntityType<T>): Effect.Effect<void, CacheError>;
   get(id: string): Effect.Effect<Option.Option<EntityType<T>>, CacheError>;

--- a/std-toolkit/cache/src/cache-single-item.ts
+++ b/std-toolkit/cache/src/cache-single-item.ts
@@ -3,11 +3,19 @@ import type { Effect, Option } from 'effect';
 import type { CacheError } from './error.js';
 import type { AnySingleEntityESchema } from '@std-toolkit/eschema';
 
+/**
+ * Subset of an `AnySingleEntityESchema` that the single-item cache cares
+ * about. Includes `Encoded` so cache rows are typed as the encoded shape.
+ */
 export type CacheSingleItemSchemaType = Pick<
   AnySingleEntityESchema,
-  'name' | 'Type'
+  'name' | 'Type' | 'Encoded'
 >;
 
+/**
+ * Single-item cache contract — `T` is the **encoded** shape of the entity
+ * (`ESchemaEncoded<S>`). Decoding happens at the collection boundary.
+ */
 export interface CacheSingleItem<T> {
   put(item: EntityType<T>): Effect.Effect<void, CacheError>;
   get(): Effect.Effect<Option.Option<EntityType<T>>, CacheError>;

--- a/std-toolkit/cache/src/idb/idb-cache-entity.ts
+++ b/std-toolkit/cache/src/idb/idb-cache-entity.ts
@@ -15,7 +15,7 @@ import {
 
 export class IDBCacheEntity<
   TSchema extends CacheSchemaType,
-> implements CacheEntity<TSchema['Type']> {
+> implements CacheEntity<TSchema['Encoded']> {
   #dbName: string;
   #entity: string;
   #partition: string;
@@ -83,7 +83,7 @@ export class IDBCacheEntity<
     });
   }
 
-  put(item: EntityType<TSchema['Type']>): Effect.Effect<void, CacheError> {
+  put(item: EntityType<TSchema['Encoded']>): Effect.Effect<void, CacheError> {
     return Effect.tryPromise({
       try: () => {
         const id = String(item.value[this.#eschema.idField]);
@@ -101,7 +101,7 @@ export class IDBCacheEntity<
 
   get(
     id: string,
-  ): Effect.Effect<Option.Option<EntityType<TSchema['Type']>>, CacheError> {
+  ): Effect.Effect<Option.Option<EntityType<TSchema['Encoded']>>, CacheError> {
     return Effect.tryPromise({
       try: async () => {
         const item: StoredItem | undefined = await this.#db.get(
@@ -112,7 +112,7 @@ export class IDBCacheEntity<
         if (!item) return Option.none();
 
         return Option.some({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         });
       },
@@ -120,7 +120,7 @@ export class IDBCacheEntity<
     });
   }
 
-  getAll(): Effect.Effect<EntityType<TSchema['Type']>[], CacheError> {
+  getAll(): Effect.Effect<EntityType<TSchema['Encoded']>[], CacheError> {
     return Effect.tryPromise({
       try: async () => {
         const items: StoredItem[] = await this.#db.getAll(
@@ -129,7 +129,7 @@ export class IDBCacheEntity<
         );
 
         return items.map((item) => ({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         }));
       },
@@ -138,7 +138,7 @@ export class IDBCacheEntity<
   }
 
   getLatest(): Effect.Effect<
-    Option.Option<EntityType<TSchema['Type']>>,
+    Option.Option<EntityType<TSchema['Encoded']>>,
     CacheError
   > {
     return Effect.tryPromise({
@@ -151,7 +151,7 @@ export class IDBCacheEntity<
 
         const item = cursor.value as StoredItem;
         return Option.some({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         });
       },
@@ -161,7 +161,7 @@ export class IDBCacheEntity<
   }
 
   getOldest(): Effect.Effect<
-    Option.Option<EntityType<TSchema['Type']>>,
+    Option.Option<EntityType<TSchema['Encoded']>>,
     CacheError
   > {
     return Effect.tryPromise({
@@ -174,7 +174,7 @@ export class IDBCacheEntity<
 
         const item = cursor.value as StoredItem;
         return Option.some({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         });
       },

--- a/std-toolkit/cache/src/idb/idb-cache-single-item.ts
+++ b/std-toolkit/cache/src/idb/idb-cache-single-item.ts
@@ -19,7 +19,7 @@ const SINGLETON_ID = '__singleton__';
 
 export class IDBCacheSingleItem<
   TSchema extends CacheSingleItemSchemaType,
-> implements CacheSingleItem<TSchema['Type']> {
+> implements CacheSingleItem<TSchema['Encoded']> {
   #dbName: string;
   #entity: string;
   #partition: string;
@@ -68,7 +68,7 @@ export class IDBCacheSingleItem<
     });
   }
 
-  put(item: EntityType<TSchema['Type']>): Effect.Effect<void, CacheError> {
+  put(item: EntityType<TSchema['Encoded']>): Effect.Effect<void, CacheError> {
     return Effect.tryPromise({
       try: () => {
         const stored: StoredItem = {
@@ -84,7 +84,10 @@ export class IDBCacheSingleItem<
     }).pipe(Effect.asVoid);
   }
 
-  get(): Effect.Effect<Option.Option<EntityType<TSchema['Type']>>, CacheError> {
+  get(): Effect.Effect<
+    Option.Option<EntityType<TSchema['Encoded']>>,
+    CacheError
+  > {
     return Effect.tryPromise({
       try: async () => {
         const item: StoredItem | undefined = await this.#db.get(
@@ -95,7 +98,7 @@ export class IDBCacheSingleItem<
         if (!item) return Option.none();
 
         return Option.some({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         });
       },

--- a/std-toolkit/cache/src/memory/memory-cache-entity.ts
+++ b/std-toolkit/cache/src/memory/memory-cache-entity.ts
@@ -15,7 +15,7 @@ const stringOrder = Order.string;
 
 export class MemoryCacheEntity<
   TSchema extends CacheESchema,
-> implements CacheEntity<TSchema['Type']> {
+> implements CacheEntity<TSchema['Encoded']> {
   #store = new Map<string, StoredItem>();
   #eschema: TSchema;
   #updatedIndex: SortedMap.SortedMap<string, string>;
@@ -31,7 +31,7 @@ export class MemoryCacheEntity<
     return Effect.succeed(new MemoryCacheEntity(options.eschema));
   }
 
-  put(item: EntityType<TSchema['Type']>): Effect.Effect<void, CacheError> {
+  put(item: EntityType<TSchema['Encoded']>): Effect.Effect<void, CacheError> {
     return Effect.try({
       try: () => {
         const id = String(item.value[this.#eschema.idField]);
@@ -57,7 +57,7 @@ export class MemoryCacheEntity<
 
   get(
     id: string,
-  ): Effect.Effect<Option.Option<EntityType<TSchema['Type']>>, CacheError> {
+  ): Effect.Effect<Option.Option<EntityType<TSchema['Encoded']>>, CacheError> {
     return Effect.try({
       try: () => {
         const item = this.#store.get(id);
@@ -65,7 +65,7 @@ export class MemoryCacheEntity<
         if (!item) return Option.none();
 
         return Option.some({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         });
       },
@@ -73,11 +73,11 @@ export class MemoryCacheEntity<
     });
   }
 
-  getAll(): Effect.Effect<EntityType<TSchema['Type']>[], CacheError> {
+  getAll(): Effect.Effect<EntityType<TSchema['Encoded']>[], CacheError> {
     return Effect.try({
       try: () =>
         Array.from(this.#store.values(), (item) => ({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         })),
       catch: (cause) => CacheError.getFailed('Failed to get all items', cause),
@@ -85,7 +85,7 @@ export class MemoryCacheEntity<
   }
 
   getLatest(): Effect.Effect<
-    Option.Option<EntityType<TSchema['Type']>>,
+    Option.Option<EntityType<TSchema['Encoded']>>,
     CacheError
   > {
     return Effect.try({
@@ -98,7 +98,7 @@ export class MemoryCacheEntity<
         if (!item) return Option.none();
 
         return Option.some({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         });
       },
@@ -108,7 +108,7 @@ export class MemoryCacheEntity<
   }
 
   getOldest(): Effect.Effect<
-    Option.Option<EntityType<TSchema['Type']>>,
+    Option.Option<EntityType<TSchema['Encoded']>>,
     CacheError
   > {
     return Effect.try({
@@ -121,7 +121,7 @@ export class MemoryCacheEntity<
         if (!item) return Option.none();
 
         return Option.some({
-          value: item.value as TSchema['Type'],
+          value: item.value as TSchema['Encoded'],
           meta: item.meta,
         });
       },

--- a/std-toolkit/core/src/index.ts
+++ b/std-toolkit/core/src/index.ts
@@ -1,8 +1,11 @@
 export {
   EntityType,
+  EntityRow,
+  RowMeta,
   BroadcastSchema,
   MetaSchema,
   EntitySchema,
+  makeEntityRow,
 } from './schema.js';
 
 export type {

--- a/std-toolkit/core/src/schema.ts
+++ b/std-toolkit/core/src/schema.ts
@@ -1,5 +1,10 @@
-import { Schema } from 'effect';
-import { AnyESchema } from '@std-toolkit/eschema';
+import { Effect, Schema } from 'effect';
+import {
+  AnyESchema,
+  ESchemaEncoded,
+  ESchemaError,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 
 export const MetaSchema = Schema.Struct({
   _v: Schema.String,
@@ -8,10 +13,43 @@ export const MetaSchema = Schema.Struct({
   _u: Schema.String,
 });
 
+export type RowMeta = typeof MetaSchema.Type;
+
+/**
+ * Wire / cache shape: `value` is the JSON-safe encoded form of an ESchema
+ * (`ESchemaEncoded<S>`) plus the entity meta. Anything that crosses a
+ * serialization boundary uses this shape.
+ */
 export type EntityType<T> = {
   value: T;
-  meta: typeof MetaSchema.Type;
+  meta: RowMeta;
 };
+
+/**
+ * Server-side row returned by db entity services. Carries the encoded `value`
+ * (ready to forward to wire / cache / broadcast at zero cost) plus a memoized
+ * `decoded` Effect that yields the rich, decoded `ESchemaType<S>` on demand.
+ */
+export type EntityRow<S extends AnyESchema> = EntityType<ESchemaEncoded<S>> & {
+  decoded: Effect.Effect<ESchemaType<S>, ESchemaError>;
+};
+
+/**
+ * Builds an `EntityRow<S>` from an already-encoded value plus meta. The
+ * `decoded` Effect is memoized via `Effect.cached` so consumers pay the
+ * decode cost at most once per row.
+ */
+export const makeEntityRow = <S extends AnyESchema>(
+  eschema: S,
+  value: ESchemaEncoded<S>,
+  meta: RowMeta,
+): Effect.Effect<EntityRow<S>> =>
+  Effect.gen(function* () {
+    const decoded = yield* Effect.cached(
+      eschema.decode(value) as Effect.Effect<ESchemaType<S>, ESchemaError>,
+    );
+    return { value, meta, decoded };
+  });
 
 export const BroadcastSchema = Schema.Struct({
   _tag: Schema.Literal('@std-toolkit/broadcast'),
@@ -20,8 +58,17 @@ export const BroadcastSchema = Schema.Struct({
   ),
 });
 
+/**
+ * Wire schema for a single entity row over RPC. `value` is the **encoded**
+ * shape of the eschema (`ESchemaEncoded<S>` — JSON-safe primitives + `_v`),
+ * not the decoded `Type`. Consumers (e.g. `stdCollectionOptions`) decode
+ * explicitly at the collection boundary.
+ */
 export const EntitySchema = <S extends AnyESchema>(eschema: S) =>
   Schema.Struct({
-    value: eschema.schema as unknown as Schema.Schema<S['Type'], S['Type']>,
+    value: Schema.encodedSchema(eschema.schema) as unknown as Schema.Schema<
+      ESchemaEncoded<S>,
+      ESchemaEncoded<S>
+    >,
     meta: MetaSchema,
   });

--- a/std-toolkit/db-dynamodb/src/rpc/delete.ts
+++ b/std-toolkit/db-dynamodb/src/rpc/delete.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/dynamo-entity.js';
+import type { AnyEntityESchema, ESchemaEncoded } from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { DynamodbError } from '../errors.js';
-import { type AnyDynamoEntity, mapError } from './types.js';
+import { type AnyDynamoEntity, mapError, stripDecoded } from './types.js';
 
 export const makeDeleteHandler = <
   TSchema extends AnyEntityESchema,
@@ -14,10 +14,9 @@ export const makeDeleteHandler = <
   eschema: TSchema,
   prefix?: P,
 ) => {
-  type Entity = ESchemaType<TSchema>;
   type IdField = TSchema['idField'];
   type DeletePayload = Record<IdField, string>;
-  type Result = EntityType<Entity>;
+  type Result = EntityType<ESchemaEncoded<TSchema>>;
 
   const idField = eschema.idField as IdField;
 
@@ -29,8 +28,11 @@ export const makeDeleteHandler = <
     ] as string;
     const keyValue = { [idField]: id } as any;
     return (
-      entity.delete(keyValue) as Effect.Effect<Result, DynamodbError>
-    ).pipe(Effect.mapError(mapError));
+      entity.delete(keyValue) as Effect.Effect<
+        EntityRow<TSchema>,
+        DynamodbError
+      >
+    ).pipe(Effect.map(stripDecoded), Effect.mapError(mapError));
   };
 
   const p = (prefix ?? '') as P;

--- a/std-toolkit/db-dynamodb/src/rpc/get.ts
+++ b/std-toolkit/db-dynamodb/src/rpc/get.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/dynamo-entity.js';
+import type { AnyEntityESchema, ESchemaEncoded } from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { DynamodbError } from '../errors.js';
-import { type AnyDynamoEntity, mapError } from './types.js';
+import { type AnyDynamoEntity, mapError, stripDecoded } from './types.js';
 
 export const makeGetHandler = <
   TSchema extends AnyEntityESchema,
@@ -14,10 +14,9 @@ export const makeGetHandler = <
   eschema: TSchema,
   prefix?: P,
 ) => {
-  type Entity = ESchemaType<TSchema>;
   type IdField = TSchema['idField'];
   type GetPayload = Record<IdField, string>;
-  type Result = EntityType<Entity> | null;
+  type Result = EntityType<ESchemaEncoded<TSchema>> | null;
 
   const idField = eschema.idField as IdField;
 
@@ -28,7 +27,13 @@ export const makeGetHandler = <
       idField as string
     ] as string;
     const keyValue = { [idField]: id } as any;
-    return (entity.get(keyValue) as Effect.Effect<Result, DynamodbError>).pipe(
+    return (
+      entity.get(keyValue) as Effect.Effect<
+        EntityRow<TSchema> | null,
+        DynamodbError
+      >
+    ).pipe(
+      Effect.map((row) => (row ? stripDecoded(row) : null)),
       Effect.mapError(mapError),
     );
   };

--- a/std-toolkit/db-dynamodb/src/rpc/insert.ts
+++ b/std-toolkit/db-dynamodb/src/rpc/insert.ts
@@ -1,9 +1,13 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/dynamo-entity.js';
+import type {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { DynamodbError } from '../errors.js';
-import { type AnyDynamoEntity, mapError } from './types.js';
+import { type AnyDynamoEntity, mapError, stripDecoded } from './types.js';
 
 export const makeInsertHandler = <
   TSchema extends AnyEntityESchema,
@@ -17,14 +21,17 @@ export const makeInsertHandler = <
   type Entity = ESchemaType<TSchema>;
   type IdField = TSchema['idField'];
   type InsertPayload = Omit<Entity, IdField>;
-  type Result = EntityType<Entity>;
+  type Result = EntityType<ESchemaEncoded<TSchema>>;
 
   const handler = (
     payload: InsertPayload,
   ): Effect.Effect<Result, StdToolkitError> =>
     (
-      entity.insert(payload as any) as Effect.Effect<Result, DynamodbError>
-    ).pipe(Effect.mapError(mapError));
+      entity.insert(payload as any) as Effect.Effect<
+        EntityRow<TSchema>,
+        DynamodbError
+      >
+    ).pipe(Effect.map(stripDecoded), Effect.mapError(mapError));
 
   const p = (prefix ?? '') as P;
   const handlerName = `${p}insert${eschema.name}` as const;

--- a/std-toolkit/db-dynamodb/src/rpc/types.ts
+++ b/std-toolkit/db-dynamodb/src/rpc/types.ts
@@ -1,9 +1,10 @@
-import type { AnyEntityESchema } from '@std-toolkit/eschema';
+import type { AnyEntityESchema, ESchemaEncoded } from '@std-toolkit/eschema';
 import type { DynamoEntity } from '../services/dynamo-entity.js';
 import type { StoredIndexDerivation } from '../services/dynamo-entity.js';
 import type { DynamoTable } from '../services/dynamo-table.js';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
 import { DynamodbError } from '../errors.js';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 
 export type AnyDynamoEntity<S extends AnyEntityESchema = AnyEntityESchema> =
   DynamoEntity<
@@ -18,3 +19,11 @@ export const mapError = (error: DynamodbError): StdToolkitError =>
     message: error.error._tag,
     code: error.error._tag,
   });
+
+/**
+ * Drops the server-only `decoded` Effect from a row before it crosses an RPC
+ * boundary (the wire schema is `EntityType<ESchemaEncoded<S>>`, no closures).
+ */
+export const stripDecoded = <S extends AnyEntityESchema>(
+  row: EntityRow<S>,
+): EntityType<ESchemaEncoded<S>> => ({ value: row.value, meta: row.meta });

--- a/std-toolkit/db-dynamodb/src/rpc/update.ts
+++ b/std-toolkit/db-dynamodb/src/rpc/update.ts
@@ -1,9 +1,13 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/dynamo-entity.js';
+import type {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { DynamodbError } from '../errors.js';
-import { type AnyDynamoEntity, mapError } from './types.js';
+import { type AnyDynamoEntity, mapError, stripDecoded } from './types.js';
 
 export const makeUpdateHandler = <
   TSchema extends AnyEntityESchema,
@@ -21,7 +25,7 @@ export const makeUpdateHandler = <
   type UpdatePayload = {
     readonly updates: PartialWithUndefined<InsertPayload>;
   } & Record<IdField, string>;
-  type Result = EntityType<Entity>;
+  type Result = EntityType<ESchemaEncoded<TSchema>>;
 
   const idField = eschema.idField as IdField;
 
@@ -36,8 +40,8 @@ export const makeUpdateHandler = <
     return (
       entity.update(keyValue, {
         update: typedPayload.updates as any,
-      }) as Effect.Effect<Result, DynamodbError>
-    ).pipe(Effect.mapError(mapError));
+      }) as Effect.Effect<EntityRow<TSchema>, DynamodbError>
+    ).pipe(Effect.map(stripDecoded), Effect.mapError(mapError));
   };
 
   const p = (prefix ?? '') as P;

--- a/std-toolkit/db-dynamodb/src/services/dynamo-entity.ts
+++ b/std-toolkit/db-dynamodb/src/services/dynamo-entity.ts
@@ -1,7 +1,16 @@
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
+import type {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 import { Chunk, Effect, Option, Schema, Stream } from 'effect';
 import type { DynamoTable } from './dynamo-table.js';
 import { ConnectionService } from '@std-toolkit/core/server';
+import {
+  type EntityRow,
+  type EntityType as CoreEntityType,
+  makeEntityRow,
+} from '@std-toolkit/core';
 import { DynamodbError } from '../errors.js';
 import type {
   IndexDefinition,
@@ -94,16 +103,21 @@ function extractKeysFromOps(
 }
 
 /**
- * Represents an entity item with its value and metadata.
- *
- * @typeParam T - The entity value type
+ * Re-export the canonical `EntityType` and `EntityRow` shapes from core so
+ * dynamo-entity callers see the same wire/server contracts.
  */
-export interface EntityType<T> {
-  /** The entity data */
-  value: T;
-  /** Metadata about the entity item */
-  meta: MetaType;
-}
+export type { EntityType, EntityRow } from '@std-toolkit/core';
+
+/**
+ * Strips the server-only `decoded` Effect from a row before it crosses a
+ * JSON-serialization boundary (broadcast frame, transaction broadcast).
+ */
+const stripDecoded = <S extends AnyEntityESchema>(
+  row: EntityRow<S>,
+): CoreEntityType<ESchemaEncoded<S>> => ({
+  value: row.value,
+  meta: row.meta,
+});
 
 /**
  * Input type for insert operations. Omits the internal `_v` field.
@@ -256,12 +270,12 @@ export class DynamoEntity<
   #secondaryDerivations: TSecondaryDerivationMap;
   #derivationDeps: Set<string>;
 
-  #broadcast(entity: EntityType<ESchemaType<TSchema>>) {
+  #broadcast(row: EntityRow<TSchema>) {
     return Effect.gen(this, function* () {
       const service = yield* Effect.serviceOption(ConnectionService).pipe(
         Effect.andThen(Option.getOrNull),
       );
-      service?.broadcast(entity);
+      service?.broadcast(stripDecoded(row));
     });
   }
 
@@ -344,7 +358,7 @@ export class DynamoEntity<
     keyValue: IndexPkValue<ESchemaType<TSchema>, TPrimaryPkKeys> &
       Pick<ESchemaType<TSchema>, TSchema['idField']>,
     options?: { ConsistentRead?: boolean },
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>> | null, DynamodbError> {
+  ): Effect.Effect<EntityRow<TSchema> | null, DynamodbError> {
     return Effect.gen(this, function* () {
       const pk = deriveIndexKeyValue(
         this.#eschema.name,
@@ -363,16 +377,7 @@ export class DynamoEntity<
 
       if (!Item) return null;
 
-      const value = yield* this.#eschema
-        .decode(Item)
-        .pipe(Effect.mapError((e) => DynamodbError.getItemFailed(e)));
-
-      const meta = Schema.decodeUnknownSync(metaSchema)(Item);
-
-      return {
-        value: value as ESchemaType<TSchema>,
-        meta,
-      };
+      return yield* this.#parseItem(Item);
     }).pipe(
       Effect.tapError((e) =>
         Effect.logError(`[${this.#eschema.name}] get failed`, { error: e }),
@@ -392,14 +397,14 @@ export class DynamoEntity<
     options?: {
       condition?: ConditionInput<ESchemaType<TSchema>>;
     },
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>, DynamodbError> {
+  ): Effect.Effect<EntityRow<TSchema>, DynamodbError> {
     return Effect.gen(this, function* () {
       const fullValueWithId = {
         ...value,
         _v: this.#eschema.latestVersion,
       } as unknown as ESchemaType<TSchema>;
 
-      const { item, exprResult, meta, fullValue } = yield* this.#prepareInsert(
+      const { item, exprResult, meta, encoded } = yield* this.#prepareInsert(
         fullValueWithId,
         options?.condition,
       );
@@ -414,9 +419,13 @@ export class DynamoEntity<
           ),
         );
 
-      const entity = { value: fullValue, meta };
-      yield* this.#broadcast(entity);
-      return entity;
+      const row = yield* makeEntityRow(
+        this.#eschema,
+        encoded as ESchemaEncoded<TSchema>,
+        meta,
+      );
+      yield* this.#broadcast(row);
+      return row;
     }).pipe(
       Effect.tapError((e) =>
         Effect.logError(`[${this.#eschema.name}] insert failed`, { error: e }),
@@ -445,7 +454,7 @@ export class DynamoEntity<
           ) => AnyOperation<ESchemaType<TSchema>>[]);
       condition?: ConditionInput<ESchemaType<TSchema>>;
     },
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>, DynamodbError> {
+  ): Effect.Effect<EntityRow<TSchema>, DynamodbError> {
     const { update: updates, condition } = params;
     return Effect.gen(this, function* () {
       const { pk, sk, exprResult } =
@@ -476,20 +485,9 @@ export class DynamoEntity<
         return yield* Effect.fail(DynamodbError.noItemToUpdate());
       }
 
-      const decodedValue = yield* this.#eschema
-        .decode(result.Attributes)
-        .pipe(Effect.mapError((e) => DynamodbError.updateItemFailed(e)));
-
-      const updatedMeta = Schema.decodeUnknownSync(metaSchema)(
-        result.Attributes,
-      );
-
-      const entity = {
-        value: decodedValue as ESchemaType<TSchema>,
-        meta: updatedMeta,
-      };
-      yield* this.#broadcast(entity);
-      return entity;
+      const row = yield* this.#parseItem(result.Attributes);
+      yield* this.#broadcast(row);
+      return row;
     }).pipe(
       Effect.tapError((e) =>
         Effect.logError(`[${this.#eschema.name}] update failed`, { error: e }),
@@ -536,7 +534,7 @@ export class DynamoEntity<
     options?: {
       forceDelete?: 'I know what I am doing';
     },
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>, DynamodbError> {
+  ): Effect.Effect<EntityRow<TSchema>, DynamodbError> {
     return Effect.gen(this, function* () {
       const existing = yield* this.get(keyValue);
       if (!existing) {
@@ -559,10 +557,10 @@ export class DynamoEntity<
 
         yield* this.#table.deleteItem({ pk, sk });
 
-        const deleted = {
-          value: existing.value,
-          meta: { ...existing.meta, _d: true },
-        };
+        const deleted = yield* makeEntityRow(this.#eschema, existing.value, {
+          ...existing.meta,
+          _d: true,
+        });
         yield* this.#broadcast(deleted);
         return deleted;
       }
@@ -599,7 +597,7 @@ export class DynamoEntity<
         _v: this.#eschema.latestVersion,
       } as unknown as ESchemaType<TSchema>;
 
-      const { item, exprResult, meta, fullValue } = yield* this.#prepareInsert(
+      const { item, exprResult, meta, encoded } = yield* this.#prepareInsert(
         fullValueWithId,
         options?.condition,
       );
@@ -608,7 +606,7 @@ export class DynamoEntity<
       return {
         ...tableOp,
         entityName: this.#eschema.name,
-        broadcast: { value: fullValue, meta },
+        broadcast: { value: encoded, meta },
       };
     });
   }
@@ -655,16 +653,29 @@ export class DynamoEntity<
               condition,
             );
 
-      const mergedValue =
-        typeof updates === 'function'
-          ? existing.value
-          : ({ ...existing.value, ...updates } as ESchemaType<TSchema>);
+      let broadcastValue: ESchemaEncoded<TSchema>;
+      if (typeof updates === 'function') {
+        broadcastValue = existing.value;
+      } else {
+        const decodedExisting = yield* existing.decoded.pipe(
+          Effect.mapError((e) => DynamodbError.updateItemFailed(e)),
+        );
+        const merged = {
+          ...decodedExisting,
+          ...updates,
+        } as ESchemaType<TSchema>;
+        broadcastValue = (yield* this.#eschema
+          .encode(merged as any)
+          .pipe(
+            Effect.mapError((e) => DynamodbError.updateItemFailed(e)),
+          )) as ESchemaEncoded<TSchema>;
+      }
 
       const tableOp = this.#table.opUpdateItem({ pk, sk }, exprResult);
       return {
         ...tableOp,
         entityName: this.#eschema.name,
-        broadcast: { value: mergedValue, meta },
+        broadcast: { value: broadcastValue, meta },
       };
     });
   }
@@ -702,10 +713,7 @@ export class DynamoEntity<
           }
         : never,
     options?: SimpleQueryOptions,
-  ): Effect.Effect<
-    { items: EntityType<ESchemaType<TSchema>>[] },
-    DynamodbError
-  > {
+  ): Effect.Effect<{ items: EntityRow<TSchema>[] }, DynamodbError> {
     return Effect.gen(this, function* () {
       const { operator, value: skValue } = extractKeyOp(params.sk as SkParam);
       const scanForward = getKeyOpScanDirection(operator);
@@ -816,7 +824,7 @@ export class DynamoEntity<
           }
         : never,
     options?: QueryStreamOptions,
-  ): Stream.Stream<EntityType<ESchemaType<TSchema>>[], DynamodbError> {
+  ): Stream.Stream<EntityRow<TSchema>[], DynamodbError> {
     const batchSize = options?.batchSize ?? 100;
     const operator = '>' in params.sk ? '>' : '<';
     const initialSkValue = '>' in params.sk ? params.sk['>'] : params.sk['<'];
@@ -910,7 +918,7 @@ export class DynamoEntity<
           queryOptions,
         );
 
-        service?.emit(result.items);
+        service?.emit(result.items.map(stripDecoded));
 
         const lastItem = result.items[result.items.length - 1];
         if (!lastItem) {
@@ -1007,20 +1015,33 @@ export class DynamoEntity<
     };
   }
 
+  #parseItem(item: unknown): Effect.Effect<EntityRow<TSchema>, DynamodbError> {
+    return Effect.gen(this, function* () {
+      const meta = Schema.decodeUnknownSync(metaSchema)(item);
+      const encoded = this.#extractEncoded(item);
+      return yield* makeEntityRow(this.#eschema, encoded, meta);
+    });
+  }
+
+  /**
+   * Picks the encoded eschema fields (declared fields + `_v`) out of a raw
+   * dynamo Item, dropping storage-only columns (`pk`, `sk`, index columns)
+   * and meta (`_e`, `_u`, `_d`) so `row.value` carries only what
+   * `ESchemaEncoded<TSchema>` describes.
+   */
+  #extractEncoded(item: unknown): ESchemaEncoded<TSchema> {
+    const obj = item as Record<string, unknown>;
+    const out: Record<string, unknown> = { _v: obj._v };
+    for (const key of Object.keys(this.#eschema.fields)) {
+      if (key in obj) out[key] = obj[key];
+    }
+    return out as ESchemaEncoded<TSchema>;
+  }
+
   #decodeItems(
     items: unknown[],
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>[], DynamodbError> {
-    return Effect.all(
-      items.map((item) =>
-        this.#eschema.decode(item).pipe(
-          Effect.map((value) => ({
-            value: value as ESchemaType<TSchema>,
-            meta: Schema.decodeUnknownSync(metaSchema)(item),
-          })),
-          Effect.mapError((e) => DynamodbError.queryFailed(e)),
-        ),
-      ),
-    );
+  ): Effect.Effect<EntityRow<TSchema>[], DynamodbError> {
+    return Effect.all(items.map((item) => this.#parseItem(item)));
   }
 
   #prepareInsert(
@@ -1031,7 +1052,7 @@ export class DynamoEntity<
       item: Record<string, unknown>;
       exprResult: ConditionExprResult;
       meta: MetaType;
-      fullValue: ESchemaType<TSchema>;
+      encoded: ESchemaEncoded<TSchema>;
     },
     DynamodbError
   > {
@@ -1077,7 +1098,12 @@ export class DynamoEntity<
         ),
       });
 
-      return { item, exprResult, meta, fullValue };
+      return {
+        item,
+        exprResult,
+        meta,
+        encoded: encoded as ESchemaEncoded<TSchema>,
+      };
     });
   }
 

--- a/std-toolkit/db-sqlite/src/rpc/delete.ts
+++ b/std-toolkit/db-sqlite/src/rpc/delete.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/sqlite-entity.js';
+import type { AnyEntityESchema, ESchemaEncoded } from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { SqliteDB, SqliteDBError } from '../sql/db.js';
-import { type AnySQLiteEntity, mapError } from './types.js';
+import { type AnySQLiteEntity, mapError, stripDecoded } from './types.js';
 
 export const makeDeleteHandler = <
   TSchema extends AnyEntityESchema,
@@ -14,10 +14,9 @@ export const makeDeleteHandler = <
   eschema: TSchema,
   prefix?: P,
 ) => {
-  type Entity = ESchemaType<TSchema>;
   type IdField = TSchema['idField'];
   type DeletePayload = Record<IdField, string>;
-  type Result = EntityType<Entity>;
+  type Result = EntityType<ESchemaEncoded<TSchema>>;
 
   const idField = eschema.idField as IdField;
 
@@ -29,8 +28,12 @@ export const makeDeleteHandler = <
     ] as string;
     const keyValue = { [idField]: id } as any;
     return (
-      entity.delete(keyValue) as Effect.Effect<Result, SqliteDBError, SqliteDB>
-    ).pipe(Effect.mapError(mapError));
+      entity.delete(keyValue) as Effect.Effect<
+        EntityRow<TSchema>,
+        SqliteDBError,
+        SqliteDB
+      >
+    ).pipe(Effect.map(stripDecoded), Effect.mapError(mapError));
   };
 
   const p = (prefix ?? '') as P;

--- a/std-toolkit/db-sqlite/src/rpc/get.ts
+++ b/std-toolkit/db-sqlite/src/rpc/get.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/sqlite-entity.js';
+import type { AnyEntityESchema, ESchemaEncoded } from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { SqliteDB, SqliteDBError } from '../sql/db.js';
-import { type AnySQLiteEntity, mapError } from './types.js';
+import { type AnySQLiteEntity, mapError, stripDecoded } from './types.js';
 
 export const makeGetHandler = <
   TSchema extends AnyEntityESchema,
@@ -14,10 +14,9 @@ export const makeGetHandler = <
   eschema: TSchema,
   prefix?: P,
 ) => {
-  type Entity = ESchemaType<TSchema>;
   type IdField = TSchema['idField'];
   type GetPayload = Record<IdField, string>;
-  type Result = EntityType<Entity> | null;
+  type Result = EntityType<ESchemaEncoded<TSchema>> | null;
 
   const idField = eschema.idField as IdField;
 
@@ -29,8 +28,15 @@ export const makeGetHandler = <
     ] as string;
     const keyValue = { [idField]: id } as any;
     return (
-      entity.get(keyValue) as Effect.Effect<Result, SqliteDBError, SqliteDB>
-    ).pipe(Effect.mapError(mapError));
+      entity.get(keyValue) as Effect.Effect<
+        EntityRow<TSchema> | null,
+        SqliteDBError,
+        SqliteDB
+      >
+    ).pipe(
+      Effect.map((row) => (row ? stripDecoded(row) : null)),
+      Effect.mapError(mapError),
+    );
   };
 
   const p = (prefix ?? '') as P;

--- a/std-toolkit/db-sqlite/src/rpc/insert.ts
+++ b/std-toolkit/db-sqlite/src/rpc/insert.ts
@@ -1,9 +1,13 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/sqlite-entity.js';
+import type {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { SqliteDB, SqliteDBError } from '../sql/db.js';
-import { type AnySQLiteEntity, mapError } from './types.js';
+import { type AnySQLiteEntity, mapError, stripDecoded } from './types.js';
 
 export const makeInsertHandler = <
   TSchema extends AnyEntityESchema,
@@ -17,18 +21,18 @@ export const makeInsertHandler = <
   type Entity = ESchemaType<TSchema>;
   type IdField = TSchema['idField'];
   type InsertPayload = Omit<Entity, IdField>;
-  type Result = EntityType<Entity>;
+  type Result = EntityType<ESchemaEncoded<TSchema>>;
 
   const handler = (
     payload: InsertPayload,
   ): Effect.Effect<Result, StdToolkitError, SqliteDB> =>
     (
       entity.insert(payload as any) as Effect.Effect<
-        Result,
+        EntityRow<TSchema>,
         SqliteDBError,
         SqliteDB
       >
-    ).pipe(Effect.mapError(mapError));
+    ).pipe(Effect.map(stripDecoded), Effect.mapError(mapError));
 
   const p = (prefix ?? '') as P;
   const handlerName = `${p}insert${eschema.name}` as const;

--- a/std-toolkit/db-sqlite/src/rpc/types.ts
+++ b/std-toolkit/db-sqlite/src/rpc/types.ts
@@ -1,8 +1,9 @@
-import type { AnyEntityESchema } from '@std-toolkit/eschema';
+import type { AnyEntityESchema, ESchemaEncoded } from '@std-toolkit/eschema';
 import type { SQLiteEntity } from '../services/sqlite-entity.js';
 import type { StoredIndexDerivation } from '../internal/utils.js';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
 import { SqliteDBError } from '../sql/db.js';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 
 export type AnySQLiteEntity<S extends AnyEntityESchema = AnyEntityESchema> =
   SQLiteEntity<Record<string, StoredIndexDerivation>, S, string>;
@@ -12,3 +13,11 @@ export const mapError = (error: SqliteDBError): StdToolkitError =>
     message: error._tag,
     code: error._tag,
   });
+
+/**
+ * Drops the server-only `decoded` Effect from a row before it crosses an RPC
+ * boundary (the wire schema is `EntityType<ESchemaEncoded<S>>`, no closures).
+ */
+export const stripDecoded = <S extends AnyEntityESchema>(
+  row: EntityRow<S>,
+): EntityType<ESchemaEncoded<S>> => ({ value: row.value, meta: row.meta });

--- a/std-toolkit/db-sqlite/src/rpc/update.ts
+++ b/std-toolkit/db-sqlite/src/rpc/update.ts
@@ -1,9 +1,13 @@
 import { Effect } from 'effect';
 import { StdToolkitError } from '@std-toolkit/core/rpc';
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
-import type { EntityType } from '../services/sqlite-entity.js';
+import type {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
+import type { EntityRow, EntityType } from '@std-toolkit/core';
 import { SqliteDB, SqliteDBError } from '../sql/db.js';
-import { type AnySQLiteEntity, mapError } from './types.js';
+import { type AnySQLiteEntity, mapError, stripDecoded } from './types.js';
 
 export const makeUpdateHandler = <
   TSchema extends AnyEntityESchema,
@@ -21,7 +25,7 @@ export const makeUpdateHandler = <
   type UpdatePayload = {
     readonly updates: PartialWithUndefined<InsertPayload>;
   } & Record<IdField, string>;
-  type Result = EntityType<Entity>;
+  type Result = EntityType<ESchemaEncoded<TSchema>>;
 
   const idField = eschema.idField as IdField;
 
@@ -35,11 +39,11 @@ export const makeUpdateHandler = <
     const keyValue = { [idField]: id } as any;
     return (
       entity.update(keyValue, typedPayload.updates as any) as Effect.Effect<
-        Result,
+        EntityRow<TSchema>,
         SqliteDBError,
         SqliteDB
       >
-    ).pipe(Effect.mapError(mapError));
+    ).pipe(Effect.map(stripDecoded), Effect.mapError(mapError));
   };
 
   const p = (prefix ?? '') as P;

--- a/std-toolkit/db-sqlite/src/services/sqlite-entity.ts
+++ b/std-toolkit/db-sqlite/src/services/sqlite-entity.ts
@@ -1,4 +1,8 @@
-import type { AnyEntityESchema, ESchemaType } from '@std-toolkit/eschema';
+import type {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 import { Chunk, Effect, FiberRef, Option, Schema, Stream } from 'effect';
 import type { SQLiteTableInstance, SortKeyCondition } from './sqlite-table.js';
 import {
@@ -23,7 +27,13 @@ import {
   type StoredIndexDerivation,
   type StoredPrimaryDerivation,
 } from '../internal/utils.js';
-import type { StdDescriptor, IndexPatternDescriptor } from '@std-toolkit/core';
+import type {
+  EntityRow,
+  EntityType,
+  StdDescriptor,
+  IndexPatternDescriptor,
+} from '@std-toolkit/core';
+import { makeEntityRow } from '@std-toolkit/core';
 import { ConnectionService } from '@std-toolkit/core/server';
 import { Prettify } from '@std-toolkit/eschema/types.js';
 
@@ -74,17 +84,15 @@ type ResolveStreamSkParam<
  */
 type InsertInput<T> = Omit<T, '_v'>;
 
+export type { EntityType, EntityRow } from '@std-toolkit/core';
+
 /**
- * Represents an entity item with its value and metadata.
- *
- * @typeParam T - The entity value type
+ * Strips the server-only `decoded` Effect from an `EntityRow` so the row can
+ * cross a JSON serialization boundary (broadcast frames, FiberRef storage).
  */
-export interface EntityType<T> {
-  /** The entity data */
-  value: T;
-  /** Metadata about the entity item */
-  meta: RowMeta;
-}
+const stripDecoded = <S extends AnyEntityESchema>(
+  row: EntityRow<S>,
+): EntityType<ESchemaEncoded<S>> => ({ value: row.value, meta: row.meta });
 
 /**
  * Helper type to extract the key type from an array of keys.
@@ -231,11 +239,7 @@ export class SQLiteEntity<
   get(
     keyValue: IndexKeyFields<ESchemaType<TSchema>, TPrimaryPkKeys> &
       Pick<ESchemaType<TSchema>, TSchema['idField']>,
-  ): Effect.Effect<
-    EntityType<ESchemaType<TSchema>> | null,
-    SqliteDBError,
-    SqliteDB
-  > {
+  ): Effect.Effect<EntityRow<TSchema> | null, SqliteDBError, SqliteDB> {
     return Effect.gen(this, function* () {
       const pk = deriveIndexKeyValue(
         this.#eschema.name,
@@ -266,20 +270,24 @@ export class SQLiteEntity<
    */
   insert(
     value: InsertInput<ESchemaType<TSchema>>,
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>, SqliteDBError, SqliteDB> {
+  ): Effect.Effect<EntityRow<TSchema>, SqliteDBError, SqliteDB> {
     return Effect.gen(this, function* () {
       const fullValue = {
         ...value,
         _v: this.#eschema.latestVersion,
       } as unknown as ESchemaType<TSchema>;
 
-      const { item, meta } = yield* this.#prepareInsert(fullValue);
+      const { item, encoded, meta } = yield* this.#prepareInsert(fullValue);
 
       yield* this.#table.putItem(item);
 
-      yield* this.#broadcast({ value: fullValue, meta });
-
-      return { value: fullValue, meta };
+      const row = yield* makeEntityRow(
+        this.#eschema,
+        encoded as ESchemaEncoded<TSchema>,
+        meta,
+      );
+      yield* this.#broadcast(row);
+      return row;
     });
   }
 
@@ -294,9 +302,8 @@ export class SQLiteEntity<
     keyValue: IndexKeyFields<ESchemaType<TSchema>, TPrimaryPkKeys> &
       Pick<ESchemaType<TSchema>, TSchema['idField']>,
     updates: Partial<Omit<ESchemaType<TSchema>, '_v'>>,
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>, SqliteDBError, SqliteDB> {
+  ): Effect.Effect<EntityRow<TSchema>, SqliteDBError, SqliteDB> {
     return Effect.gen(this, function* () {
-      // Get existing item
       const existing = yield* this.get(keyValue);
       if (!existing) {
         return yield* Effect.fail(
@@ -304,9 +311,14 @@ export class SQLiteEntity<
         );
       }
 
-      // Merge updates
+      const existingDecoded = yield* existing.decoded.pipe(
+        Effect.mapError((e) =>
+          SqliteDBError.updateFailed(this.#table.tableName, e),
+        ),
+      );
+
       const fullValue = {
-        ...existing.value,
+        ...existingDecoded,
         ...updates,
       } as ESchemaType<TSchema>;
 
@@ -315,7 +327,6 @@ export class SQLiteEntity<
         existing.meta._d,
       );
 
-      // Compute primary keys
       const pk = deriveIndexKeyValue(
         this.#eschema.name,
         this.#primaryDerivation.pkDeps,
@@ -329,7 +340,6 @@ export class SQLiteEntity<
         false,
       );
 
-      // Update the item
       const updateValues: Record<string, unknown> = {
         _data: JSON.stringify(encoded),
         _v: meta._v,
@@ -339,9 +349,13 @@ export class SQLiteEntity<
 
       yield* this.#table.updateItem({ pk, sk }, updateValues);
 
-      yield* this.#broadcast({ value: fullValue, meta });
-
-      return { value: fullValue, meta };
+      const row = yield* makeEntityRow(
+        this.#eschema,
+        encoded as ESchemaEncoded<TSchema>,
+        meta,
+      );
+      yield* this.#broadcast(row);
+      return row;
     });
   }
 
@@ -355,7 +369,7 @@ export class SQLiteEntity<
   delete(
     keyValue: IndexKeyFields<ESchemaType<TSchema>, TPrimaryPkKeys> &
       Pick<ESchemaType<TSchema>, TSchema['idField']>,
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>, SqliteDBError, SqliteDB> {
+  ): Effect.Effect<EntityRow<TSchema>, SqliteDBError, SqliteDB> {
     return Effect.gen(this, function* () {
       const existing = yield* this.get(keyValue);
       if (!existing) {
@@ -363,6 +377,12 @@ export class SQLiteEntity<
           SqliteDBError.deleteFailed(this.#table.tableName, 'Item not found'),
         );
       }
+
+      const existingDecoded = yield* existing.decoded.pipe(
+        Effect.mapError((e) =>
+          SqliteDBError.deleteFailed(this.#table.tableName, e),
+        ),
+      );
 
       const pk = deriveIndexKeyValue(
         this.#eschema.name,
@@ -378,27 +398,25 @@ export class SQLiteEntity<
       );
 
       // Generate new _u and encode with _d: true for soft delete
-      const { encoded, meta } = yield* this.#encode(existing.value, true);
+      const { encoded, meta } = yield* this.#encode(existingDecoded, true);
 
-      // Update the item with _d: true and new _u (soft delete)
       const updateValues: Record<string, unknown> = {
         _data: JSON.stringify(encoded),
         _v: meta._v,
         _u: meta._u,
         _d: 1,
-        ...this.#deriveSecondaryIndexes({ ...existing.value, _u: meta._u }),
+        ...this.#deriveSecondaryIndexes({ ...existingDecoded, _u: meta._u }),
       };
 
       yield* this.#table.updateItem({ pk, sk }, updateValues);
 
-      const deletedEntity = {
-        value: existing.value,
+      const row = yield* makeEntityRow(
+        this.#eschema,
+        encoded as ESchemaEncoded<TSchema>,
         meta,
-      };
-
-      yield* this.#broadcast(deletedEntity);
-
-      return deletedEntity;
+      );
+      yield* this.#broadcast(row);
+      return row;
     });
   }
 
@@ -433,11 +451,7 @@ export class SQLiteEntity<
           }
         : never,
     options?: SimpleQueryOptions,
-  ): Effect.Effect<
-    { items: EntityType<ESchemaType<TSchema>>[] },
-    SqliteDBError,
-    SqliteDB
-  > {
+  ): Effect.Effect<{ items: EntityRow<TSchema>[] }, SqliteDBError, SqliteDB> {
     return Effect.gen(this, function* () {
       const { operator, value: skValue } = extractKeyOp(params.sk as SkParam);
       const scanForward = getKeyOpScanDirection(operator);
@@ -554,11 +568,7 @@ export class SQLiteEntity<
           }
         : never,
     options?: QueryStreamOptions,
-  ): Stream.Stream<
-    EntityType<ESchemaType<TSchema>>[],
-    SqliteDBError,
-    SqliteDB
-  > {
+  ): Stream.Stream<EntityRow<TSchema>[], SqliteDBError, SqliteDB> {
     const batchSize = options?.batchSize ?? 100;
     const operator = '>' in params.sk ? '>' : '<';
     const initialSkValue = '>' in params.sk ? params.sk['>'] : params.sk['<'];
@@ -649,7 +659,7 @@ export class SQLiteEntity<
           queryOptions,
         );
 
-        service?.emit(result.items);
+        service?.emit(result.items.map(stripDecoded));
 
         const lastItem = result.items[result.items.length - 1];
         if (!lastItem) {
@@ -673,27 +683,30 @@ export class SQLiteEntity<
 
   // ─── Private Helpers ───────────────────────────────────────────────────────
 
-  #broadcast(entity: EntityType<ESchemaType<TSchema>>) {
+  #broadcast(row: EntityRow<TSchema>) {
     return Effect.gen(this, function* () {
+      const wireRow = stripDecoded(row);
       const pending = yield* FiberRef.get(TransactionPendingBroadcasts);
       if (Option.isSome(pending)) {
         yield* FiberRef.set(
           TransactionPendingBroadcasts,
-          Option.some([...pending.value, entity]),
+          Option.some([...pending.value, wireRow]),
         );
       } else {
         const service = yield* Effect.serviceOption(ConnectionService).pipe(
           Effect.andThen(Option.getOrNull),
         );
-        service?.broadcast(entity);
+        service?.broadcast(wireRow);
       }
     });
   }
 
-  #prepareInsert(
-    fullValue: ESchemaType<TSchema>,
-  ): Effect.Effect<
-    { item: Record<string, unknown>; meta: RowMeta },
+  #prepareInsert(fullValue: ESchemaType<TSchema>): Effect.Effect<
+    {
+      item: Record<string, unknown>;
+      encoded: Record<string, unknown>;
+      meta: RowMeta;
+    },
     SqliteDBError
   > {
     return Effect.gen(this, function* () {
@@ -714,7 +727,7 @@ export class SQLiteEntity<
         ...secondaryIndexes,
       };
 
-      return { item, meta };
+      return { item, encoded, meta };
     });
   }
 
@@ -745,32 +758,25 @@ export class SQLiteEntity<
       );
   }
 
-  #parseRow(
-    row: RawRow,
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>, SqliteDBError> {
-    return this.#eschema
-      .decode({ ...JSON.parse(row._data), _v: row._v })
-      .pipe(
-        Effect.mapError((e) =>
-          SqliteDBError.queryFailed(this.#table.tableName, e),
-        ),
-      )
-      .pipe(
-        Effect.map((value) => ({
-          value: value as ESchemaType<TSchema>,
-          meta: Schema.decodeSync(sqlMetaSchema)({
-            _v: row._v,
-            _u: row._u,
-            _d: row._d,
-            _e: row._e ?? this.#eschema.name,
-          }),
-        })),
-      );
+  #parseRow(row: RawRow): Effect.Effect<EntityRow<TSchema>, SqliteDBError> {
+    return Effect.gen(this, function* () {
+      const encoded = {
+        ...JSON.parse(row._data),
+        _v: row._v,
+      } as ESchemaEncoded<TSchema>;
+      const meta = Schema.decodeSync(sqlMetaSchema)({
+        _v: row._v,
+        _u: row._u,
+        _d: row._d,
+        _e: row._e ?? this.#eschema.name,
+      });
+      return yield* makeEntityRow(this.#eschema, encoded, meta);
+    });
   }
 
   #decodeItems(
     items: RawRow[],
-  ): Effect.Effect<EntityType<ESchemaType<TSchema>>[], SqliteDBError> {
+  ): Effect.Effect<EntityRow<TSchema>[], SqliteDBError> {
     return Effect.all(items.map((item) => this.#parseRow(item)));
   }
 

--- a/std-toolkit/db-sqlite/src/services/sqlite-single-entity.ts
+++ b/std-toolkit/db-sqlite/src/services/sqlite-single-entity.ts
@@ -1,4 +1,8 @@
-import type { AnySingleEntityESchema, ESchemaType } from '@std-toolkit/eschema';
+import type {
+  AnySingleEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 import { Effect, FiberRef, Option, Schema } from 'effect';
 import type { EntityType } from '@std-toolkit/core';
 import type { SQLiteTableInstance } from './sqlite-table.js';
@@ -201,8 +205,10 @@ export class SQLiteSingleEntity<
         });
       }
 
-      const entity = { value: fullValue, meta: { ...meta, _d: false } };
-      yield* this.#broadcast(entity);
+      yield* this.#broadcast({
+        value: encoded as ESchemaEncoded<TSchema>,
+        meta: { ...meta, _d: false },
+      });
       return { value: fullValue, meta };
     });
   }
@@ -261,15 +267,17 @@ export class SQLiteSingleEntity<
 
       yield* this.#table.updateItem({ pk, sk }, updateValues);
 
-      const entity = { value: fullValue, meta: { ...meta, _d: false } };
-      yield* this.#broadcast(entity);
+      yield* this.#broadcast({
+        value: encoded as ESchemaEncoded<TSchema>,
+        meta: { ...meta, _d: false },
+      });
       return { value: fullValue, meta };
     });
   }
 
   // ─── Private Helpers ───────────────────────────────────────────────────────
 
-  #broadcast(entity: EntityType<ESchemaType<TSchema>>) {
+  #broadcast(entity: EntityType<ESchemaEncoded<TSchema>>) {
     return Effect.gen(this, function* () {
       const pending = yield* FiberRef.get(TransactionPendingBroadcasts);
       if (Option.isSome(pending)) {

--- a/std-toolkit/tanstack/src/__tests__/index.test.ts
+++ b/std-toolkit/tanstack/src/__tests__/index.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { Effect, Schema, SubscriptionRef } from 'effect';
-import { EntityESchema, SingleEntityESchema } from '@std-toolkit/eschema';
+import {
+  EntityESchema,
+  SingleEntityESchema,
+  ESchemaEncoded,
+} from '@std-toolkit/eschema';
 import { EntityType } from '@std-toolkit/core';
 import { MemoryCacheEntity } from '@std-toolkit/cache/memory';
 import {
@@ -15,12 +19,13 @@ const TestSchema = EntityESchema.make('TestEntity', 'id', {
 }).build();
 
 type TestItem = typeof TestSchema.Type;
+type TestEncoded = ESchemaEncoded<typeof TestSchema>;
 
 const createEntity = (
   value: TestItem,
-  meta: Partial<EntityType<TestItem>['meta']> = {},
-): EntityType<TestItem> => ({
-  value,
+  meta: Partial<EntityType<TestEncoded>['meta']> = {},
+): EntityType<TestEncoded> => ({
+  value: { ...value, _v: 'v1' as const },
   meta: {
     _v: 'v1',
     _e: 'TestEntity',
@@ -206,12 +211,13 @@ const SingleTestSchema = SingleEntityESchema.make('AppSettings', {
 }).build();
 
 type SingleTestItem = typeof SingleTestSchema.Type;
+type SingleTestEncoded = ESchemaEncoded<typeof SingleTestSchema>;
 
 const createSingleEntity = (
   value: SingleTestItem,
-  meta: Partial<EntityType<SingleTestItem>['meta']> = {},
-): EntityType<SingleTestItem> => ({
-  value,
+  meta: Partial<EntityType<SingleTestEncoded>['meta']> = {},
+): EntityType<SingleTestEncoded> => ({
+  value: { ...value, _v: 'v1' as const },
   meta: {
     _v: 'v1',
     _e: 'AppSettings',

--- a/std-toolkit/tanstack/src/broadcast.ts
+++ b/std-toolkit/tanstack/src/broadcast.ts
@@ -49,6 +49,8 @@ export const collectionRegistry = {
         process: (message: unknown, persist = false) => {
           if (!Schema.is(BroadcastSchema)(message)) return;
 
+          // Wire frames carry encoded values. Each collection's `upsert`
+          // decodes via its own schema before applying to the store.
           for (const value of message.values) {
             const target = entries.find(
               (e) => value.meta._e === e.utils.schema().name,

--- a/std-toolkit/tanstack/src/internal/codec.ts
+++ b/std-toolkit/tanstack/src/internal/codec.ts
@@ -1,0 +1,46 @@
+import { Effect } from 'effect';
+import type { EntityType } from '@std-toolkit/core';
+import type {
+  AnyESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
+import type { CollectionItem } from '../types.js';
+
+/**
+ * Decodes an encoded `EntityType<ESchemaEncoded<S>>` (the wire/cache shape)
+ * into a `CollectionItem<ESchemaType<S>>` ready for the TanStack store. Runs
+ * the eschema decode synchronously so failures bubble up as exceptions —
+ * decode errors at the collection boundary indicate schema drift and should
+ * be loud, not silently dropped.
+ */
+export const decodeRow = <S extends AnyESchema>(
+  schema: S,
+  row: EntityType<ESchemaEncoded<S>>,
+): CollectionItem<ESchemaType<S>> => {
+  const decoded = Effect.runSync(schema.decode(row.value)) as ESchemaType<S>;
+  return { ...decoded, _meta: row.meta } as CollectionItem<ESchemaType<S>>;
+};
+
+/**
+ * Encodes a `CollectionItem<ESchemaType<S>>` back to the wire shape
+ * `EntityType<ESchemaEncoded<S>>`. The `_meta` is split out — it lives in
+ * `meta` on the wire, not as a property on `value`.
+ */
+export const encodeRow = <S extends AnyESchema>(
+  schema: S,
+  item: CollectionItem<ESchemaType<S>>,
+): EntityType<ESchemaEncoded<S>> => {
+  const { _meta, ...rest } = item as CollectionItem<ESchemaType<S>> & {
+    _meta?: EntityType<unknown>['meta'];
+  };
+  if (!_meta) {
+    throw new Error(
+      '[std-toolkit/tanstack] encodeRow: collection item is missing _meta',
+    );
+  }
+  const encoded = Effect.runSync(
+    schema.encode(rest as ESchemaType<S>),
+  ) as ESchemaEncoded<S>;
+  return { value: encoded, meta: _meta };
+};

--- a/std-toolkit/tanstack/src/internal/collection-options.ts
+++ b/std-toolkit/tanstack/src/internal/collection-options.ts
@@ -8,7 +8,12 @@ import { Effect, Fiber, Option, Scope, SubscriptionRef } from 'effect';
 import { EntityType } from '@std-toolkit/core';
 import { CacheEntity } from '@std-toolkit/cache';
 import { MemoryCacheEntity } from '@std-toolkit/cache/memory';
-import { AnyEntityESchema, ESchemaIdField } from '@std-toolkit/eschema';
+import {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaIdField,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 import {
   parseLoadSubsetOptions,
   type ParsedLoadSubsetOptions,
@@ -21,63 +26,67 @@ import {
   makeWithSyncGuard,
 } from './shared.js';
 
-type GetMoreFn<TItem extends object> = (
-  cursor: EntityType<TItem> | null,
-) => Effect.Effect<EntityType<TItem>[]>;
+type EncodedRow<TSchema extends AnyEntityESchema> = EntityType<
+  ESchemaEncoded<TSchema>
+>;
 
-type OnLoadSubsetFn<TItem extends object> = (
-  options: ParsedLoadSubsetOptions<TItem>,
-) => Effect.Effect<EntityType<TItem>[]>;
+type GetMoreFn<TSchema extends AnyEntityESchema> = (
+  cursor: EncodedRow<TSchema> | null,
+) => Effect.Effect<EncodedRow<TSchema>[]>;
 
-type SyncFn<TItem extends object> = (
-  emit: (items: EntityType<TItem> | EntityType<TItem>[]) => void,
+type OnLoadSubsetFn<TSchema extends AnyEntityESchema> = (
+  options: ParsedLoadSubsetOptions<ESchemaType<TSchema>>,
+) => Effect.Effect<EncodedRow<TSchema>[]>;
+
+type SyncFn<TSchema extends AnyEntityESchema> = (
+  emit: (items: EncodedRow<TSchema> | EncodedRow<TSchema>[]) => void,
 ) => Effect.Effect<void, never, Scope.Scope>;
 
-interface StdCollectionConfigBase<
-  TItem extends object,
-  TSchema extends AnyEntityESchema,
-> {
+interface StdCollectionConfigBase<TSchema extends AnyEntityESchema> {
   id?: string;
   schema: TSchema;
-  cache?: Effect.Effect<CacheEntity<TItem>>;
-  onInsert?: (item: TItem) => Effect.Effect<EntityType<TItem>>;
+  cache?: Effect.Effect<CacheEntity<ESchemaEncoded<TSchema>>>;
+  onInsert?: (item: ESchemaType<TSchema>) => Effect.Effect<EncodedRow<TSchema>>;
   onUpdate?: (
     payload: {
       [K in ESchemaIdField<TSchema>]: string;
     } & {
-      updates: Partial<Omit<TItem, ESchemaIdField<TSchema>>>;
+      updates: Partial<Omit<ESchemaType<TSchema>, ESchemaIdField<TSchema>>>;
     },
-  ) => Effect.Effect<EntityType<TItem>>;
+  ) => Effect.Effect<EncodedRow<TSchema>>;
 }
 
-type StdCollectionConfig<
-  TItem extends object,
-  TSchema extends AnyEntityESchema,
-> = StdCollectionConfigBase<TItem, TSchema> &
-  (
-    | { syncMode: 'eager'; getMore: GetMoreFn<TItem>; sync?: SyncFn<TItem> }
-    | { syncMode: 'on-demand'; onLoadSubset: OnLoadSubsetFn<TItem> }
-    | {
-        syncMode: 'progressive';
-        getMore: GetMoreFn<TItem>;
-        onLoadSubset: OnLoadSubsetFn<TItem>;
-        sync?: SyncFn<TItem>;
-      }
-  );
+type StdCollectionConfig<TSchema extends AnyEntityESchema> =
+  StdCollectionConfigBase<TSchema> &
+    (
+      | {
+          syncMode: 'eager';
+          getMore: GetMoreFn<TSchema>;
+          sync?: SyncFn<TSchema>;
+        }
+      | { syncMode: 'on-demand'; onLoadSubset: OnLoadSubsetFn<TSchema> }
+      | {
+          syncMode: 'progressive';
+          getMore: GetMoreFn<TSchema>;
+          onLoadSubset: OnLoadSubsetFn<TSchema>;
+          sync?: SyncFn<TSchema>;
+        }
+    );
 
 export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
-  options: StdCollectionConfig<TSchema['Type'], TSchema>,
+  options: StdCollectionConfig<TSchema>,
 ): Omit<
   CollectionConfig<
-    CollectionItem<TSchema['Type']>,
+    CollectionItem<ESchemaType<TSchema>>,
     string,
     never,
     CollectionUtils<TSchema>
   >,
   'schema'
 > => {
-  type TItem = TSchema['Type'];
+  type TItem = ESchemaType<TSchema>;
   type TCollectionItem = CollectionItem<TItem>;
+  type TEncoded = ESchemaEncoded<TSchema>;
 
   const { id, onInsert, cache: providedCache, onUpdate, schema } = options;
   const syncMode = options.syncMode;
@@ -90,21 +99,21 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
   const semaphore = Effect.runSync(Effect.makeSemaphore(1));
   const withSyncGuard = makeWithSyncGuard(syncing, semaphore);
 
-  let resolvedCache: CacheEntity<TItem> | null = null;
+  let resolvedCache: CacheEntity<TEncoded> | null = null;
   let applyToCollection:
-    | ((items: EntityType<TItem>[], persist?: boolean) => void)
+    | ((items: EncodedRow<TSchema>[], persist?: boolean) => void)
     | null = null;
 
   const cacheAndApply = (
-    cache: CacheEntity<TItem>,
-    items: EntityType<TItem>[],
+    cache: CacheEntity<TEncoded>,
+    items: EncodedRow<TSchema>[],
   ) =>
     Effect.gen(function* () {
       yield* Effect.forEach(
         items,
         (item) =>
           Effect.gen(function* () {
-            const id = item.value[schema.idField as keyof TItem] as string;
+            const id = item.value[schema.idField as keyof TEncoded] as string;
             const existing = yield* cache.get(id);
             const existingU = Option.map(existing, (e) => e.meta._u ?? '').pipe(
               Option.getOrElse(() => ''),
@@ -119,7 +128,7 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
       applyToCollection?.(items);
     });
 
-  const fetchOnePage = (cache: CacheEntity<TItem>) =>
+  const fetchOnePage = (cache: CacheEntity<TEncoded>) =>
     Effect.gen(function* () {
       if (!getMore) return 0;
       const latest = yield* cache.getLatest();
@@ -129,7 +138,7 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
       return items.length;
     });
 
-  const fetchAllPages = (cache: CacheEntity<TItem>) =>
+  const fetchAllPages = (cache: CacheEntity<TEncoded>) =>
     Effect.gen(function* () {
       let total = 0;
 
@@ -159,12 +168,20 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
       const { markReady } = params;
 
       const initEffect = Effect.gen(function* () {
-        const cache: CacheEntity<TItem> = yield* (
-          providedCache ?? MemoryCacheEntity.make({ eschema: schema })
+        const cache: CacheEntity<TEncoded> = yield* (
+          providedCache ??
+            (MemoryCacheEntity.make({
+              eschema: schema,
+            }) as unknown as Effect.Effect<CacheEntity<TEncoded>>)
         );
 
         resolvedCache = cache;
-        applyToCollection = makeApplyToCollection(params, cache, false);
+        applyToCollection = makeApplyToCollection<TSchema>(
+          schema,
+          params,
+          cache,
+          false,
+        );
 
         if (syncMode !== 'on-demand') {
           const cachedItems = yield* cache.getAll();
@@ -175,7 +192,7 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
         }
 
         if (syncFn) {
-          const emit = (input: EntityType<TItem> | EntityType<TItem>[]) => {
+          const emit = (input: EncodedRow<TSchema> | EncodedRow<TSchema>[]) => {
             const items = Array.isArray(input) ? input : [input];
             applyToCollection?.(items, false);
           };
@@ -222,7 +239,7 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
   };
 
   const upsert = (
-    input: EntityType<TItem> | EntityType<TItem>[],
+    input: EncodedRow<TSchema> | EncodedRow<TSchema>[],
     persist?: boolean,
   ) => {
     const items = Array.isArray(input) ? input : [input];
@@ -230,7 +247,7 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
   };
 
   const guardedFetch = (
-    fn: (cache: CacheEntity<TItem>) => Effect.Effect<number, unknown>,
+    fn: (cache: CacheEntity<TEncoded>) => Effect.Effect<number, unknown>,
   ): Effect.Effect<number> =>
     Effect.suspend(() => {
       if (!resolvedCache) return Effect.succeed(0);
@@ -254,6 +271,6 @@ export const stdCollectionOptions = <TSchema extends AnyEntityESchema>(
       isSyncing: () => syncing,
     },
     compare: compareByMeta,
-    ...makeMutationHandlers(schema, upsert, onInsert, onUpdate),
+    ...makeMutationHandlers<TItem, TSchema>(schema, upsert, onInsert, onUpdate),
   };
 };

--- a/std-toolkit/tanstack/src/internal/partitioned-collection-options.ts
+++ b/std-toolkit/tanstack/src/internal/partitioned-collection-options.ts
@@ -11,7 +11,12 @@ import {
   type PartitionKey,
   serializePartition,
 } from '@std-toolkit/cache';
-import { AnyEntityESchema, ESchemaIdField } from '@std-toolkit/eschema';
+import {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaIdField,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 import { parseLoadSubsetOptions } from '../load-subset-parser.js';
 import { CollectionItem, CollectionUtils } from '../types.js';
 import {
@@ -20,45 +25,49 @@ import {
   makeMutationHandlers,
 } from './shared.js';
 
-type OnLoadPartitionFn<TItem extends object> = (
-  partition: PartitionKey,
-  cursor: EntityType<TItem> | null,
-) => Effect.Effect<EntityType<TItem>[]>;
+type EncodedRow<TSchema extends AnyEntityESchema> = EntityType<
+  ESchemaEncoded<TSchema>
+>;
 
-interface StdPartitionedCollectionConfig<
-  TItem extends object,
-  TSchema extends AnyEntityESchema,
-> {
+type OnLoadPartitionFn<TSchema extends AnyEntityESchema> = (
+  partition: PartitionKey,
+  cursor: EncodedRow<TSchema> | null,
+) => Effect.Effect<EncodedRow<TSchema>[]>;
+
+interface StdPartitionedCollectionConfig<TSchema extends AnyEntityESchema> {
   id?: string;
   schema: TSchema;
-  partitionField: string & keyof TItem;
-  cache: (partition: PartitionKey) => Effect.Effect<CacheEntity<TItem>>;
-  onLoadPartition: OnLoadPartitionFn<TItem>;
-  onInsert?: (item: TItem) => Effect.Effect<EntityType<TItem>>;
+  partitionField: string & keyof ESchemaType<TSchema>;
+  cache: (
+    partition: PartitionKey,
+  ) => Effect.Effect<CacheEntity<ESchemaEncoded<TSchema>>>;
+  onLoadPartition: OnLoadPartitionFn<TSchema>;
+  onInsert?: (item: ESchemaType<TSchema>) => Effect.Effect<EncodedRow<TSchema>>;
   onUpdate?: (
     payload: {
       [K in ESchemaIdField<TSchema>]: string;
     } & {
-      updates: Partial<Omit<TItem, ESchemaIdField<TSchema>>>;
+      updates: Partial<Omit<ESchemaType<TSchema>, ESchemaIdField<TSchema>>>;
     },
-  ) => Effect.Effect<EntityType<TItem>>;
+  ) => Effect.Effect<EncodedRow<TSchema>>;
 }
 
 export const stdPartitionedCollectionOptions = <
   TSchema extends AnyEntityESchema,
 >(
-  options: StdPartitionedCollectionConfig<TSchema['Type'], TSchema>,
+  options: StdPartitionedCollectionConfig<TSchema>,
 ): Omit<
   CollectionConfig<
-    CollectionItem<TSchema['Type']>,
+    CollectionItem<ESchemaType<TSchema>>,
     string,
     never,
     CollectionUtils<TSchema>
   >,
   'schema'
 > => {
-  type TItem = TSchema['Type'];
+  type TItem = ESchemaType<TSchema>;
   type TCollectionItem = CollectionItem<TItem>;
+  type TEncoded = ESchemaEncoded<TSchema>;
 
   const {
     id,
@@ -72,11 +81,11 @@ export const stdPartitionedCollectionOptions = <
 
   const syncing = Effect.runSync(SubscriptionRef.make(false));
 
-  const partitionCaches = new Map<string, CacheEntity<TItem>>();
+  const partitionCaches = new Map<string, CacheEntity<TEncoded>>();
   const loadedPartitions = new Set<string>();
   const inflight = new Map<string, Promise<void>>();
 
-  let applyToCollection: ((items: EntityType<TItem>[]) => void) | null = null;
+  let applyToCollection: ((items: EncodedRow<TSchema>[]) => void) | null = null;
 
   const updateSyncing = () => {
     Effect.runSync(SubscriptionRef.set(syncing, inflight.size > 0));
@@ -85,7 +94,7 @@ export const stdPartitionedCollectionOptions = <
   const getOrCreateCache = (
     key: string,
     partition: PartitionKey,
-  ): Effect.Effect<CacheEntity<TItem>> => {
+  ): Effect.Effect<CacheEntity<TEncoded>> => {
     const existing = partitionCaches.get(key);
     if (existing) return Effect.succeed(existing);
     return cacheFactory(partition).pipe(
@@ -98,15 +107,15 @@ export const stdPartitionedCollectionOptions = <
   };
 
   const cacheAndApply = (
-    cache: CacheEntity<TItem>,
-    items: EntityType<TItem>[],
+    cache: CacheEntity<TEncoded>,
+    items: EncodedRow<TSchema>[],
   ) =>
     Effect.gen(function* () {
       yield* Effect.forEach(
         items,
         (item) =>
           Effect.gen(function* () {
-            const id = item.value[schema.idField as keyof TItem] as string;
+            const id = item.value[schema.idField as keyof TEncoded] as string;
             const existing = yield* cache.get(id);
             const existingU = Option.map(existing, (e) => e.meta._u ?? '').pipe(
               Option.getOrElse(() => ''),
@@ -122,7 +131,7 @@ export const stdPartitionedCollectionOptions = <
     });
 
   const fetchOnePageForPartition = (
-    cache: CacheEntity<TItem>,
+    cache: CacheEntity<TEncoded>,
     partition: PartitionKey,
   ) =>
     Effect.gen(function* () {
@@ -134,7 +143,7 @@ export const stdPartitionedCollectionOptions = <
     });
 
   const fetchAllPagesForPartition = (
-    cache: CacheEntity<TItem>,
+    cache: CacheEntity<TEncoded>,
     partition: PartitionKey,
   ) =>
     Effect.gen(function* () {
@@ -185,8 +194,6 @@ export const stdPartitionedCollectionOptions = <
 
     const promise = Effect.runPromise(effect)
       .catch((err) => {
-        // Swallow so TanStack gets a resolved promise; partition stays
-        // out of loadedPartitions so next query triggers a retry.
         console.error(
           '[std-toolkit/tanstack] Failed to load partition',
           partition,
@@ -203,16 +210,12 @@ export const stdPartitionedCollectionOptions = <
     return promise;
   };
 
-  // --- TanStack sync ---
-
   const tanstackSync: TanstackSyncConfig<TCollectionItem, string> = {
     sync: (params) => {
       const { markReady } = params;
 
-      // Broadcast upserts don't persist — partition cache is populated during loadPartition
-      applyToCollection = makeApplyToCollection(params);
+      applyToCollection = makeApplyToCollection<TSchema>(schema, params);
 
-      // Partitions load on demand via loadSubset
       markReady();
 
       const loadSubset: LoadSubsetFn = (loadOptions) => {
@@ -248,12 +251,8 @@ export const stdPartitionedCollectionOptions = <
     },
   };
 
-  // --- Utils ---
-
-  // Broadcast upserts apply to TanStack only — no partition cache persist,
-  // since the data came from server and will be re-fetched on next partition load.
   const upsert = (
-    input: EntityType<TItem> | EntityType<TItem>[],
+    input: EncodedRow<TSchema> | EncodedRow<TSchema>[],
     _persist?: boolean,
   ) => {
     const items = Array.isArray(input) ? input : [input];
@@ -296,6 +295,6 @@ export const stdPartitionedCollectionOptions = <
       isSyncing: () => syncing,
     },
     compare: compareByMeta,
-    ...makeMutationHandlers(schema, upsert, onInsert, onUpdate),
+    ...makeMutationHandlers<TItem, TSchema>(schema, upsert, onInsert, onUpdate),
   };
 };

--- a/std-toolkit/tanstack/src/internal/shared.ts
+++ b/std-toolkit/tanstack/src/internal/shared.ts
@@ -2,8 +2,14 @@ import { SyncConfig as TanstackSyncConfig } from '@tanstack/react-db';
 import { Effect, Option, SubscriptionRef } from 'effect';
 import { EntityType } from '@std-toolkit/core';
 import { CacheEntity } from '@std-toolkit/cache';
-import { AnyEntityESchema, ESchemaIdField } from '@std-toolkit/eschema';
+import {
+  AnyEntityESchema,
+  ESchemaEncoded,
+  ESchemaIdField,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 import { CollectionItem } from '../types.js';
+import { decodeRow } from './codec.js';
 
 export type SyncParams<T extends object> = Parameters<
   TanstackSyncConfig<CollectionItem<T>, string>['sync']
@@ -32,19 +38,19 @@ export const makeWithSyncGuard =
       }).pipe(Effect.ensuring(SubscriptionRef.set(syncing, false))),
     );
 
-export const makeApplyToCollection = <TItem extends object>(
-  params: SyncParams<TItem>,
-  cache?: CacheEntity<TItem>,
+export const makeApplyToCollection = <TSchema extends AnyEntityESchema>(
+  schema: TSchema,
+  params: SyncParams<ESchemaType<TSchema>>,
+  cache?: CacheEntity<ESchemaEncoded<TSchema>>,
   alwaysPersist = false,
 ) => {
   const { begin, collection, commit, write } = params;
+  const idField = schema.idField as keyof ESchemaEncoded<TSchema>;
 
-  return (items: EntityType<TItem>[], persist = false) => {
+  return (items: EntityType<ESchemaEncoded<TSchema>>[], persist = false) => {
     begin({ immediate: true });
     for (const item of items) {
-      const key = collection.getKeyFromItem(
-        item.value as CollectionItem<TItem>,
-      );
+      const key = String(item.value[idField]);
       const existing = collection.get(key);
       const existingU = existing?._meta?._u ?? '';
       const incomingU = item.meta._u ?? '';
@@ -70,10 +76,7 @@ export const makeApplyToCollection = <TItem extends object>(
       if (item.meta._d) {
         if (collection.has(key)) write({ type: 'delete', key });
       } else {
-        const itemValue = {
-          ...item.value,
-          _meta: item.meta,
-        } as CollectionItem<TItem>;
+        const itemValue = decodeRow(schema, item);
         if (collection.has(key)) {
           write({ type: 'update', value: itemValue });
         } else {
@@ -90,15 +93,17 @@ export const makeMutationHandlers = <
   TSchema extends AnyEntityESchema,
 >(
   schema: TSchema,
-  upsert: (item: EntityType<TItem>) => void,
-  onInsert?: (item: TItem) => Effect.Effect<EntityType<TItem>>,
+  upsert: (item: EntityType<ESchemaEncoded<TSchema>>) => void,
+  onInsert?: (
+    item: TItem,
+  ) => Effect.Effect<EntityType<ESchemaEncoded<TSchema>>>,
   onUpdate?: (
     payload: {
       [K in ESchemaIdField<TSchema>]: string;
     } & {
       updates: Partial<Omit<TItem, ESchemaIdField<TSchema>>>;
     },
-  ) => Effect.Effect<EntityType<TItem>>,
+  ) => Effect.Effect<EntityType<ESchemaEncoded<TSchema>>>,
 ) => ({
   onInsert: async ({
     transaction,

--- a/std-toolkit/tanstack/src/internal/single-item-options.ts
+++ b/std-toolkit/tanstack/src/internal/single-item-options.ts
@@ -6,27 +6,35 @@ import {
 } from '@tanstack/react-db';
 import { Effect, Option, SubscriptionRef } from 'effect';
 import { EntityType } from '@std-toolkit/core';
-import { AnySingleEntityESchema } from '@std-toolkit/eschema';
+import {
+  AnySingleEntityESchema,
+  ESchemaEncoded,
+  ESchemaType,
+} from '@std-toolkit/eschema';
 import type { CacheSingleItem } from '@std-toolkit/cache';
 import { CollectionItem, SingleItemUtils } from '../types.js';
 import { makeWithSyncGuard } from './shared.js';
+import { decodeRow } from './codec.js';
 
-interface StdSingleItemConfig<
-  TItem extends object,
-  TSchema extends AnySingleEntityESchema,
-> {
+type EncodedItem<TSchema extends AnySingleEntityESchema> = EntityType<
+  ESchemaEncoded<TSchema>
+>;
+
+interface StdSingleItemConfig<TSchema extends AnySingleEntityESchema> {
   id?: string;
   schema: TSchema;
-  get: () => Effect.Effect<EntityType<TItem>>;
-  onUpdate?: (payload: { updates: TItem }) => Effect.Effect<EntityType<TItem>>;
-  cache?: Effect.Effect<CacheSingleItem<TItem>>;
+  get: () => Effect.Effect<EncodedItem<TSchema>>;
+  onUpdate?: (payload: {
+    updates: ESchemaType<TSchema>;
+  }) => Effect.Effect<EncodedItem<TSchema>>;
+  cache?: Effect.Effect<CacheSingleItem<ESchemaEncoded<TSchema>>>;
 }
 
 export const stdSingleItemOptions = <TSchema extends AnySingleEntityESchema>(
-  options: StdSingleItemConfig<TSchema['Type'], TSchema>,
+  options: StdSingleItemConfig<TSchema>,
 ): Omit<
   CollectionConfig<
-    CollectionItem<TSchema['Type']>,
+    CollectionItem<ESchemaType<TSchema>>,
     string,
     never,
     SingleItemUtils<TSchema>
@@ -34,8 +42,9 @@ export const stdSingleItemOptions = <TSchema extends AnySingleEntityESchema>(
   'schema'
 > &
   SingleResult => {
-  type TItem = TSchema['Type'];
+  type TItem = ESchemaType<TSchema>;
   type TCollectionItem = CollectionItem<TItem>;
+  type TEncoded = ESchemaEncoded<TSchema>;
 
   const { id, get, onUpdate, schema, cache: cacheEffect } = options;
   const singletonKey = schema.name;
@@ -44,10 +53,10 @@ export const stdSingleItemOptions = <TSchema extends AnySingleEntityESchema>(
   const semaphore = Effect.runSync(Effect.makeSemaphore(1));
   const withSyncGuard = makeWithSyncGuard(syncing, semaphore);
 
-  let applyToCollection: ((item: EntityType<TItem>) => void) | null = null;
-  let resolvedCache: CacheSingleItem<TItem> | null = null;
+  let applyToCollection: ((item: EncodedItem<TSchema>) => void) | null = null;
+  let resolvedCache: CacheSingleItem<TEncoded> | null = null;
 
-  const upsert = (item: EntityType<TItem>, persist?: boolean) => {
+  const upsert = (item: EncodedItem<TSchema>, persist?: boolean) => {
     applyToCollection?.(item);
     if (persist && resolvedCache) {
       Effect.runPromise(
@@ -61,8 +70,8 @@ export const stdSingleItemOptions = <TSchema extends AnySingleEntityESchema>(
   ) => {
     const { begin, collection, commit, write } = params;
 
-    return (item: EntityType<TItem>) => {
-      const itemValue = { ...item.value, _meta: item.meta } as TCollectionItem;
+    return (item: EncodedItem<TSchema>) => {
+      const itemValue = decodeRow(schema, item) as TCollectionItem;
       begin({ immediate: true });
       if (collection.has(singletonKey)) {
         write({ type: 'update', value: itemValue });
@@ -90,13 +99,13 @@ export const stdSingleItemOptions = <TSchema extends AnySingleEntityESchema>(
 
         if (cacheEffect) {
           resolvedCache = yield* Effect.catchAll(cacheEffect, () =>
-            Effect.succeed(null),
+            Effect.succeed(null as CacheSingleItem<TEncoded> | null),
           );
           const cached = resolvedCache
             ? yield* Effect.catchAll(resolvedCache.get(), () =>
-                Effect.succeed(Option.none<EntityType<TItem>>()),
+                Effect.succeed(Option.none<EncodedItem<TSchema>>()),
               )
-            : Option.none<EntityType<TItem>>();
+            : Option.none<EncodedItem<TSchema>>();
           if (Option.isSome(cached)) {
             applyToCollection(cached.value);
             markReady();

--- a/std-toolkit/tanstack/src/types.ts
+++ b/std-toolkit/tanstack/src/types.ts
@@ -1,8 +1,17 @@
 import { Effect, SubscriptionRef } from 'effect';
 import { EntityType, MetaSchema } from '@std-toolkit/core';
-import { AnyEntityESchema, AnySingleEntityESchema } from '@std-toolkit/eschema';
+import {
+  AnyEntityESchema,
+  AnySingleEntityESchema,
+  ESchemaEncoded,
+} from '@std-toolkit/eschema';
 import type { PartitionKey } from '@std-toolkit/cache';
 
+/**
+ * Decoded shape of an item inside a TanStack collection. `T` is
+ * `ESchemaType<S>` (the rich, decoded form). `_meta` carries the row's
+ * version/updated/deleted metadata.
+ */
 export type CollectionItem<T> = T & {
   _meta?: typeof MetaSchema.Type;
 };
@@ -10,8 +19,15 @@ export type CollectionItem<T> = T & {
 export type CollectionUtils<
   TSchema extends AnyEntityESchema = AnyEntityESchema,
 > = {
+  /**
+   * Inject a wire-shape (encoded) row (or rows) into the collection. The
+   * collection holds decoded items, so `upsert` decodes via the schema
+   * before applying.
+   */
   upsert: (
-    item: EntityType<TSchema['Type']> | EntityType<TSchema['Type']>[],
+    item:
+      | EntityType<ESchemaEncoded<TSchema>>
+      | EntityType<ESchemaEncoded<TSchema>>[],
     persist?: boolean,
   ) => void;
   schema: () => TSchema;
@@ -23,7 +39,10 @@ export type CollectionUtils<
 export type SingleItemUtils<
   TSchema extends AnySingleEntityESchema = AnySingleEntityESchema,
 > = {
-  upsert: (item: EntityType<TSchema['Type']>, persist?: boolean) => void;
+  upsert: (
+    item: EntityType<ESchemaEncoded<TSchema>>,
+    persist?: boolean,
+  ) => void;
   schema: () => TSchema;
   refetch: () => Effect.Effect<void>;
   isSyncing: () => SubscriptionRef.SubscriptionRef<boolean>;


### PR DESCRIPTION
## Summary

Establishes a single decoded/encoded boundary at `stdCollectionOptions`. Outside the collection — DB rows, RPC payloads, broadcast frames, caches — everything carries `ESchemaEncoded<S>` (JSON-safe). Inside, the TanStack store, hooks, and UI see `ESchemaType<S>` (decoded). Fixes asymmetric eschema transforms (`StringToNumber`, `Schema.DateFromString`, custom classes) silently flattening when the wire layer JSON-stringified a "decoded" value typed as if no transform had run.

```
                          ENCODED ZONE                        │   DECODED ZONE
  ┌──────────────┐    ┌────────────┐    ┌──────────────┐     │   ┌──────────────┐    ┌─────┐
  │  DDB / SQLite│◀──▶│  RPC + WS  │◀──▶│ idb / memory │  ◀──┼──▶│ TanStack DB  │──▶│ UI  │
  │              │    │  broadcast │    │   cache      │     │   │ collection   │    │     │
  └──────────────┘    └────────────┘    └──────────────┘     │   └──────────────┘    └─────┘
                                                              ▲
                                                  stdCollectionOptions
                                                   (decode in / encode out)
```

## Changes

- **core**: add `EntityRow<S> = EntityType<ESchemaEncoded<S>> & { decoded: Effect<ESchemaType<S>, ESchemaError> }` and `makeEntityRow` (Effect.cached, memoized decode). Retype `EntitySchema` so the RPC wire `value` is `Schema.encodedSchema(eschema.schema)`.
- **db-sqlite, db-dynamodb**: `get` / `query` / `queryStream` / `insert` / `update` / `delete` / `*Op` now return `EntityRow<S>`. Read paths skip eager decode; consumers opt in via `row.decoded`. `#broadcast` and `subscribe.emit` strip the `decoded` closure before crossing JSON boundaries.
- **db-sqlite, db-dynamodb RPC**: handlers return `EntityType<ESchemaEncoded<S>>` matching the new wire schema.
- **cache**: `CacheEntity<T>`, `MemoryCacheEntity`, `IDBCacheEntity`, `IDBCacheSingleItem` now hold the encoded shape (`TSchema['Encoded']`).
- **tanstack**: new `decodeRow` / `encodeRow` codec helpers. `applyToCollection` decodes encoded rows before writing into the store. `stdCollectionOptions`, `stdPartitionedCollectionOptions`, and `stdSingleItemOptions` typings: collection items are `ESchemaType<S>` (decoded) while wire callbacks (`getMore`, `onLoadSubset`, `sync`, `onInsert`, `onUpdate`) work in `EntityType<ESchemaEncoded<S>>`.

## Test plan

- [x] `pnpm lint` passes for every std-toolkit package (`eschema`, `core`, `cache`, `db-sqlite`, `db-dynamodb`, `tanstack`)
- [x] `pnpm test` passes for `eschema` (127), `core` (35), `cache` (45), `db-sqlite` (110), `tanstack` (35) — 352 tests total
- [ ] `db-dynamodb` tests skipped per instruction (need a local DynamoDB running); package typechecks clean
- [ ] End-to-end with an asymmetric transform schema (`StringToNumber`, `Schema.DateFromString`): outbound RPC body is encoded, broadcast frames are encoded, React component receives decoded values
- [ ] IDB rehydrate roundtrip: cache holds encoded, collection surfaces decoded
- [ ] Cross-tab broadcast: tab A mutate → tab B sees decoded values without manual conversion

## Migration notes

Server-side callers that previously did:
```ts
const item = yield* entity.get(...);
console.log(item.value.foo);   // decoded
```
become either:
```ts
const row = yield* entity.get(...);
console.log(row.value.foo);    // encoded — fine for forwarding to wire
// or
const item = yield* row.decoded;
console.log(item.foo);         // decoded — for business logic
```
TypeScript will guide each call site.

https://claude.ai/code/session_01Qd7GBvjqZrfoEj1H1M6iFG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd7GBvjqZrfoEj1H1M6iFG)_