### PR TITLE
docs(sync): offline writes ADR and implementation plan

### DIFF
--- a/std-toolkit/src/sync/docs/adr/0005-offline-writes-are-slots-and-named-actions.md
+++ b/std-toolkit/src/sync/docs/adr/0005-offline-writes-are-slots-and-named-actions.md
@@ -1,0 +1,111 @@
+# Offline writes are per-entity slots and named partitioned actions
+
+Sync's read side is durable — replicas, cursors, and strategy state survive
+reloads — but a write is only as durable as the tab it was made in. An
+optimistic mutation lives in TanStack DB memory until its handler confirms, so
+a reload, crash, or long offline window loses the user's edit. This ADR makes
+durability a property of the write itself.
+
+## The write is a destination, not a diary
+
+Entity-level offline writes are stored as **Outbox Slots**: at most one durable
+record per entity holding the latest desired state (`upsert`) or a tombstone
+(`delete`). A new edit overwrites the entity's slot; insert+update collapses to
+one upsert, an unsent insert followed by delete removes the slot entirely.
+Because a final state depends on nothing but itself, there is no operation
+chain, no replay ordering, and no cascading failure across entities. Operations
+whose *intent* matters — cross-entity transactions, server-computed effects —
+are not slots; they are **Offline Actions** (below).
+
+## "Last write wins" means last edit, not last arrival
+
+Ids are minted on the client (ULID), and every slot carries a `proposedU`: a
+`_u` minted at the moment the user edited, disciplined as a hybrid logical
+clock (never behind the newest `_u` this client has seen; the server rejects
+proposals too far in its future). The backend applies a slot with a conditional
+write — apply iff `proposedU` is newer than the stored `_u` — which is the
+existing client Convergence Rule enforced server-side via db `transact` check
+ops. Every delivery has one of three outcomes:
+
+- **applied** — the proposal won; the confirmed Entity flows back through
+  `applyToSyncReplica` and normal sync.
+- **superseded** — the backend already holds something newer; the server
+  returns the authoritative Entity, convergence accepts it as a no-op, and the
+  slot is dropped. Not an error, and needs no dedicated code path.
+- **rejected** — a backend invariant refused the write; the slot is dropped,
+  the optimistic state rolls back, and the failure is surfaced.
+
+Slot retries need no idempotency key: re-sending the same `proposedU` is a
+duplicate under the conditional write. Actions carry explicit idempotency keys.
+
+## Presentation goes through TanStack's front door
+
+There is no custom overlay layer. A pending offline write is a live TanStack
+optimistic mutation: the mutation handler stays unresolved until the outbox
+delivers its entry, and throws only on rejection, so TanStack's own rollback
+undoes the optimism. `$synced` and `$origin` therefore stay truthful for the
+whole offline window. On boot, replay re-invokes the same public operations —
+stored diffs for entity ops, named actions with persisted payloads — flagged as
+replays so they re-attach to their existing entries instead of enqueueing new
+ones. Closures never persist; only data does, which is why actions are named
+and payload-schema'd. Awaiting a write while offline blocks until delivery
+(Firestore semantics); a separate durable acknowledgment reports "safely
+queued".
+
+## Offline is orthogonal to pacing
+
+Pacing decides *when* to send (in-memory smoothing of rapid edits); offline
+decides *what survives* when sending fails or cannot happen. They are sibling
+collection options — any pace strategy, or none, combines with `offline`.
+Eager writes still want durability, so no combination is restricted.
+
+## Actions are named, partitioned FIFO lanes
+
+`createOfflineAction` registers a **unique, stable name** with a schema'd (and
+where possible eschema'd, hence migratable) payload, an `onMutate` optimistic
+application, and a `mutationFn` executed at drain time. Entries are addressed
+by `(namespace, action name, partition key, sequence)`. An optional
+`partition` function shards the queue into independent FIFO lanes: lanes drain
+in parallel, entries within a lane drain strictly in order, and a stuck lane
+never blocks another. On rejection a lane follows its declared policy: `halt`
+(park the lane durably, app resolves it), `discard` (drop the remainder,
+rolling back their optimism), or `continue` (fail only this entry). Entries
+whose action name no longer exists are parked and reported through
+`onUnknownAction`. Slots and action lanes are otherwise independent; overlap
+on the same entity is arbitrated by the LWW rule, and flows that need strict
+ordering belong entirely inside one action lane.
+
+## One store, one election
+
+Outbox records are new stored entities in the existing Sync Store StdTable, so
+Memory versus IndexedDB versus SQLite durability remains the platform's single
+choice, the version gate clears the outbox on dataset resets (loudly, with a
+discarded-count event), and `reset()` gives logout one wipe covering replicas,
+cursors, state, and outbox. Any tab may enqueue — store writes are
+transactional — but **only the leader drains**, as a new `OfflineDrain`
+Leadership role: one lock per collection for the entity lane (per-entity
+serialization is the drainer's in-flight map, not a lock), one lock per active
+action lane. In-flight work is not in the slot: the drainer claims a slot by
+clearing it, later edits write a fresh slot, and a landed flight resolves every
+waiter at or below the generation it carried, which keeps awaiting callers
+correct under coalescing. Completion status is broadcast on the existing peer
+channel so a non-leader tab's pending handler resolves; the store remains the
+source of truth on boot.
+
+## Why not `@tanstack/offline-transactions`
+
+The official package validates the architecture — outbox before dispatch,
+named handlers, retry with backoff, leader election, `NonRetriableError`
+classification — and its vocabulary and test scenarios are deliberately
+mirrored. It is not adopted because its semantics are the ones this design
+rejects for the entity lane: a persisted operation diary with no
+cross-transaction coalescing, one global FIFO where a stuck transaction blocks
+every entity, and non-leader tabs that do not persist offline writes at all.
+It would also duplicate storage, leader election, retry, and telemetry that
+std-toolkit already owns in Effect-native form.
+
+## Out of scope
+
+Field-level merge (entity-level LWW is deliberate; finer grains are a later
+refinement of the same rule), CRDT collaborative editing, cross-tab visibility
+of unsent optimistic state, and at-rest encryption of the local store.

--- a/std-toolkit/src/sync/docs/adr/0005-offline-writes-are-slots-and-named-actions.md
+++ b/std-toolkit/src/sync/docs/adr/0005-offline-writes-are-slots-and-named-actions.md
@@ -26,14 +26,24 @@ clock (never behind the newest update stamp this client has seen).
 **The proposal never becomes `_u`.** `_u` is also the cursor axis for
 incremental sync; writing an old edit-time stamp into `_u` would land an
 accepted write *behind* other clients' cursors, making it invisible to
-cursor-based sync forever. The two roles are split: `_u` stays server-minted
-at write time (cursor and convergence axis — every accepted write is always
-ahead of every cursor), and the entity meta gains an optional **edit stamp**
-(`_p`) recording the `proposedU` that won. The backend applies a slot with a
-conditional write via db `transact` check ops — apply iff `proposedU` is
-newer than the stored `_p` — and on apply writes a fresh server-minted `_u`
-together with `_p = proposedU`. Client convergence continues to compare `_u`
-alone and is unchanged. Every delivery has one of three outcomes:
+cursor-based sync forever. `_u` therefore stays server-minted at write time
+(cursor and convergence axis — every accepted write is always ahead of every
+cursor), and client convergence continues to compare `_u` alone, unchanged.
+
+The conditional apply is **not wired into the toolkit's server side**. The
+backend author writes it as an ordinary db conditional update in their RPC
+handler — `getAndUpdate(key, updates, { check: (current, meta) => meta._u <
+proposedU })` — with a failed check answered by returning the current
+authoritative entity (superseded). The only db change this needs is exposing
+Entity Meta to check invariants, which today receive the value alone.
+Comparing the edit-time proposal against the stored *arrival-time* `_u` is
+deliberately conservative: arrival is always at or after edit, so a stale
+edit can never overwrite a newer one, though an offline edit may be
+superseded by a competing write that *arrived* after it was made. Exact
+edit-versus-edit fairness — an optional **edit stamp** (`_p`) meta field
+recording the winning `proposedU` and compared instead of `_u` — is the
+documented refinement, not required for v1. Every delivery has one of three
+outcomes:
 
 - **applied** — the proposal won; the confirmed Entity flows back through
   `applyToSyncReplica` and normal sync.

--- a/std-toolkit/src/sync/docs/adr/0005-offline-writes-are-slots-and-named-actions.md
+++ b/std-toolkit/src/sync/docs/adr/0005-offline-writes-are-slots-and-named-actions.md
@@ -20,12 +20,20 @@ are not slots; they are **Offline Actions** (below).
 ## "Last write wins" means last edit, not last arrival
 
 Ids are minted on the client (ULID), and every slot carries a `proposedU`: a
-`_u` minted at the moment the user edited, disciplined as a hybrid logical
-clock (never behind the newest `_u` this client has seen; the server rejects
-proposals too far in its future). The backend applies a slot with a conditional
-write — apply iff `proposedU` is newer than the stored `_u` — which is the
-existing client Convergence Rule enforced server-side via db `transact` check
-ops. Every delivery has one of three outcomes:
+stamp minted at the moment the user edited, disciplined as a hybrid logical
+clock (never behind the newest update stamp this client has seen).
+
+**The proposal never becomes `_u`.** `_u` is also the cursor axis for
+incremental sync; writing an old edit-time stamp into `_u` would land an
+accepted write *behind* other clients' cursors, making it invisible to
+cursor-based sync forever. The two roles are split: `_u` stays server-minted
+at write time (cursor and convergence axis — every accepted write is always
+ahead of every cursor), and the entity meta gains an optional **edit stamp**
+(`_p`) recording the `proposedU` that won. The backend applies a slot with a
+conditional write via db `transact` check ops — apply iff `proposedU` is
+newer than the stored `_p` — and on apply writes a fresh server-minted `_u`
+together with `_p = proposedU`. Client convergence continues to compare `_u`
+alone and is unchanged. Every delivery has one of three outcomes:
 
 - **applied** — the proposal won; the confirmed Entity flows back through
   `applyToSyncReplica` and normal sync.
@@ -37,6 +45,20 @@ ops. Every delivery has one of three outcomes:
 
 Slot retries need no idempotency key: re-sending the same `proposedU` is a
 duplicate under the conditional write. Actions carry explicit idempotency keys.
+
+Clock drift is accounted for, not solved. The cursor axis is immune by
+construction (`_u` is server time only), so drift can never hide a write from
+sync. Drift affects only conflict *fairness* between the same user's devices:
+a behind-clock device is defended by the HLC floor (it can never stamp behind
+data it has already seen, so it cannot lose to itself), and an ahead-clock
+device is bounded by a server tolerance on `proposedU` (minutes ahead of
+server time; beyond it the write is refused as malformed rather than winning
+conflicts for a year). Within the tolerance, an ahead clock wins conflicts
+unfairly for its skew duration — a accepted, documented degradation, never a
+correctness or sync-visibility failure. `proposedU` is optional end to end: a
+backend that ignores it simply stamps `_u` on arrival and skips the `_p`
+compare, degrading to arrival-order LWW (today's behavior) without breaking
+anything.
 
 ## Presentation goes through TanStack's front door
 

--- a/std-toolkit/src/sync/docs/offline-plan.md
+++ b/std-toolkit/src/sync/docs/offline-plan.md
@@ -55,23 +55,36 @@ have stable identity.
 **Critical: the proposal never becomes `_u`.** `_u` is also the cursor axis —
 strategies fetch "entities beyond cursor X" by `_u` — so writing an old
 edit-time stamp into `_u` would land the accepted write *behind* other
-clients' cursors, invisible to incremental sync forever. The roles split:
+clients' cursors, invisible to incremental sync forever. `_u` stays
+**server-minted at write time**: every accepted write is ahead of every
+cursor, sync visibility never depends on a client clock, and client
+convergence keeps comparing `_u` alone — unchanged.
 
-- `_u` stays **server-minted at write time**. Every accepted write is ahead
-  of every cursor; sync visibility never depends on a client clock. Client
-  convergence keeps comparing `_u` alone — unchanged.
-- A new optional meta field, the **edit stamp `_p`**, records the winning
-  `proposedU`. The backend applies a slot conditionally: **apply iff
-  `proposedU` is newer than the stored `_p`** (db `transact` check ops),
-  writing fresh server `_u` + `_p = proposedU` on apply, and returning the
-  authoritative entity either way. So a stale device reconnecting cannot
-  overwrite a newer edit made elsewhere — its write is *superseded*, a
-  successful no-op that ordinary convergence cleans up.
+**The conditional apply is user-written, not toolkit-wired.** The backend
+author's RPC handler uses the existing db conditional update:
 
-`proposedU` is **optional end to end**: a backend that ignores it stamps `_u`
-on arrival and skips the `_p` compare — arrival-order LWW, today's behavior,
-nothing breaks. Forwarding one field and using the conditional-apply helper
-upgrades to edit-time LWW.
+```typescript
+taskEntity.getAndUpdate(key, updates, {
+  check: (current, meta) => meta._u < proposedU,
+});
+// check failed → fetch current, return it (superseded)
+```
+
+The one db change this requires: **check invariants receive Entity Meta**
+(today `EntityInvariant<T> = (current: T) => boolean` sees the value only).
+No server-side proposal machinery, no new write paths.
+
+Semantics of comparing edit-time `proposedU` against arrival-time `_u`:
+deliberately **conservative**. Arrival is always at or after edit, so a stale
+device can never overwrite a newer edit (the safe direction); the cost is
+that an offline edit may be superseded by a competing write that merely
+*arrived* after it was made. Exact edit-vs-edit fairness — an optional `_p`
+edit-stamp meta field compared instead of `_u` — is a documented later
+refinement, not v1.
+
+`proposedU` is **optional end to end**: a backend that ignores it does plain
+writes — arrival-order LWW, today's behavior, nothing breaks. Adding the one
+check clause upgrades to conservative edit-time LWW.
 
 Clock drift is **accounted for, not solved**: sync visibility is immune by
 construction (`_u` is server time). Drift affects only conflict fairness
@@ -257,10 +270,12 @@ Each phase ships and is testable independently.
 ### Phase 5 — server recipe and docs
 
 - Documented backend pattern (with example) for the conditional apply:
-  db `transact` check on the `_p` edit stamp (`proposedU > stored _p`),
-  writing fresh server-minted `_u` + `_p = proposedU` on apply, returning
-  the authoritative entity on supersession; future-bound validation of
-  `proposedU`; db support for writing `_p` alongside the server-minted `_u`.
+  `getAndUpdate` with a meta-aware check (`meta._u < proposedU`), returning
+  the authoritative entity on a failed check (supersession); future-bound
+  validation of `proposedU`. Prerequisite db change (small, may land in any
+  phase): check invariants (`EntityInvariant`, `WriteOptions.check`,
+  `getAndCheckOp`) receive Entity Meta alongside the value. The optional
+  `_p` edit-stamp refinement is documented but not implemented.
 - eschema payload guidance for actions; README/docs updates; sync stories
   covering the full user journeys (fast edits offline → reload → reconnect;
   two-device stale write; halted lane recovery).
@@ -280,10 +295,10 @@ it in the Sync Store, updating opportunistically). Mint with `ulidx`
 monotonic factory seeded at `max(Date.now(), uTime(lastSeenStamp))`;
 monotonic mode already breaks same-ms ties. The server-side recipe (phase 5)
 refuses a `proposedU` more than a configured tolerance (default: 5 minutes)
-ahead of server time as a `rejected` outcome. `proposedU` is compared only
-against the stored `_p` edit stamp — never written into or compared against
-`_u`, which remains server-minted (see "Conflicts" above). `_p` is a new
-optional Entity Meta field defined in `core` alongside `_s`/`_c`.
+ahead of server time as a `rejected` outcome. `proposedU` is never written
+into `_u`, which remains server-minted; the v1 recipe compares it against the
+stored `_u` in a user-written check (see "Conflicts" above), and the optional
+`_p` edit stamp is a later refinement.
 
 ### Stored entities (same StdTable as `sync-store.ts`)
 

--- a/std-toolkit/src/sync/docs/offline-plan.md
+++ b/std-toolkit/src/sync/docs/offline-plan.md
@@ -237,6 +237,100 @@ Each phase ships and is testable independently.
   covering the full user journeys (fast edits offline → reload → reconnect;
   two-device stale write; halted lane recovery).
 
+## Implementation contracts
+
+Mechanical details a fresh implementer should not have to guess. Where this
+section is silent, follow the existing patterns in `../CONTEXT.md`
+(vocabulary), `../../persistence/sync-store/sync-store.ts` (stored entity
+conventions), the existing workers (drain worker shape), and laymos layering.
+
+### `proposedU` minting (HLC discipline)
+
+Keep a per-Std-Sync `lastSeenU` (max of: every `_u` accepted into any replica,
+and every `proposedU` this client minted; persist it in the Sync Store,
+updating opportunistically). Mint with `ulidx` monotonic factory seeded at
+`max(Date.now(), uTime(lastSeenU))`; monotonic mode already breaks same-ms
+ties. The server-side recipe (phase 5) rejects a `proposedU` more than a
+configured tolerance (default: 5 minutes) ahead of server time as a
+`rejected` outcome.
+
+### Stored entities (same StdTable as `sync-store.ts`)
+
+Follow the existing pattern (`EntityESchema.make(...)`, `.primary({ pk:
+['collection'] })`, opaque encoded payloads via `fromType`):
+
+- `SyncStoredOutboxSlot` — key = entity id; fields: `collection`, `kind`
+  (`'upsert' | 'delete'`), `value` (encoded latest entity state; absent for
+  delete), `proposedU`, `changes` (encoded partial for replaying updates as
+  diffs), `baseKind` (`'insert' | 'existing'` — whether the entity was ever
+  confirmed, deciding insert-vs-update replay and the insert+delete
+  cancellation), `generation`, `attempts`, `enqueuedAt`.
+- `SyncStoredOutboxAction` — key = `seq` (ULID); fields: `collection`
+  (namespace), `actionName`, `partitionKey`, `payload` (encoded),
+  `idempotencyKey`, `attempts`, `enqueuedAt`.
+- `SyncStoredOutboxLane` — key = `actionName + '/' + partitionKey`; fields:
+  `collection` (namespace), `status` (`'active' | 'halted'`), `haltedBy`
+  (seq of the rejected entry, when halted).
+
+All three are added to the version-gate wipe list in `sync-store.ts`.
+
+### Error classification
+
+Add a tagged error to the sync error domain, e.g. `WriteError.Rejected`
+(exported so app handlers can `Effect.fail` it; also accept a defect whose
+value is `instanceof` an exported `NonRetriableError` class for non-Effect
+API clients). Everything else — typed or defect — is transient and retries.
+
+### Handler / waiter contract
+
+`runMutations` (in `composition/keyed-sync/mutations.ts`), when `offline` is
+on: persist/merge the slot, then `await outbox.delivered(entityId,
+generation)` instead of calling the user callback. `delivered` resolves when
+a flight carrying `>= generation` lands `applied` or `superseded`, and fails
+with the rejection when it lands `rejected`. The drain worker is what
+actually invokes the user's `onInsert`/`onUpdate`/`onDelete`; their return
+value flows to `applyToSyncReplica` exactly as today. `onInsert`'s batch
+signature is preserved by the drainer batching ready insert-slots per flight
+where convenient; correctness never depends on batching.
+
+### Replay rules (boot)
+
+1. Replica hydration and projection complete first (`Collection ready`).
+2. Entity slots replay in `enqueuedAt` order: `baseKind: 'insert'` upserts
+   replay as front-door `insert(value)`; existing-entity upserts replay as
+   `update(key, d => Object.assign(d, changes))`; deletes as `delete(key)` —
+   each with `metadata: { std: { replay: entityId } }`, which routes the
+   handler to re-attach (no new slot write, no generation bump).
+3. Action entries replay per lane in `seq` order by invoking the registered
+   action with the persisted payload and `replay` metadata. A payload that
+   fails schema decode, or an unregistered name, parks the entry
+   (`onUnknownAction`).
+4. Replay happens in every tab (optimism is per-tab); only the leader drains.
+
+### Cross-tab completion
+
+Reuse the peer channel infrastructure with a distinct envelope kind (not a
+Peer Message): `{ kind: 'outbox-outcome', entryKey, generation?, outcome }`,
+best-effort like Peer Sync — the store is the truth, and every tab's waiter
+registry also re-checks the store on reconnect/boot. Confirmed entities
+themselves still travel via existing Peer Sync.
+
+### Config types (target surface)
+
+```typescript
+type OfflineOption =
+  | boolean
+  | {
+      retry?: Schedule.Schedule<unknown>;      // default: exponential 1s..5m, jittered
+      onDiscarded?: (e: OutboxDiscardedEvent) => void;
+    };
+// createStdSync({ offline?: Omit<OfflineOption, boolean> }) sets instance defaults.
+```
+
+Action config and handle types are as sketched in "Actions" above; `done`
+resolves with `'applied'`-style outcomes for symmetry
+(`'executed' | 'rejected' | 'cancelled'`).
+
 ## Out of scope (deliberate)
 
 Field-level merge, CRDT collaborative editing, cross-tab visibility of

--- a/std-toolkit/src/sync/docs/offline-plan.md
+++ b/std-toolkit/src/sync/docs/offline-plan.md
@@ -1,0 +1,244 @@
+# Offline writes implementation plan
+
+Decisions are recorded in
+[ADR 0005](./adr/0005-offline-writes-are-slots-and-named-actions.md). This plan
+restates the problem and the solution in simple terms, then breaks the work
+into phases.
+
+## The problem
+
+Sync's read side already survives anything: replicas, cursors, and strategy
+state are persisted, so a reload rebuilds the collection from disk and resumes.
+The write side does not. An optimistic mutation lives only in TanStack DB
+memory until `onInsert` / `onUpdate` / `onDelete` confirms against the backend.
+If the tab reloads, crashes, or stays offline, the user's edit is silently
+lost. The promise an offline-capable sync engine must keep is: **an edit, once
+made, survives anything short of the user clearing their browser** — and today
+we cannot keep it.
+
+Two write shapes need this promise:
+
+1. **Entity writes** — insert/update/delete on one entity. The overwhelming
+   majority of writes.
+2. **Actions** — operations whose intent spans entities or must run on the
+   server (archive a project, move money). These cannot be reduced to a final
+   entity state.
+
+## The solution in simple terms
+
+### Entity writes: a mailbox of destinations, not a diary of trips
+
+While offline (or mid-flight), each entity has **at most one durable slot** in
+the Sync Store: the latest state the user wants (`upsert`) or a tombstone
+(`delete`). Every new edit overwrites the slot. Insert then three renames then
+"done" is one slot; insert then delete is no slot at all. When connectivity
+returns, a drain worker sends one request per touched entity, in any order —
+there is no operation chain, so one entity's failure never cascades to another.
+
+Slot coalescing rules:
+
+| existing slot            | new edit | result                       |
+| ------------------------ | -------- | ---------------------------- |
+| none                     | insert   | `upsert` (full state)        |
+| `upsert` (unsent insert) | update   | `upsert` (merged state)      |
+| `upsert` (unsent insert) | delete   | slot removed — never sent    |
+| `upsert` (existing row)  | delete   | `delete`                     |
+| `delete`                 | insert   | `upsert`                     |
+
+### Conflicts: the newest *edit* wins, not the newest *arrival*
+
+Every slot carries `proposedU` — a `_u` ULID minted the moment the user edited,
+disciplined as a hybrid logical clock (never behind the newest `_u` this client
+has seen; server rejects far-future stamps). Entity ids are minted on the
+client so offline inserts have stable identity. The backend applies a slot
+conditionally: **apply iff `proposedU` is newer than the stored `_u`** (db
+`transact` check ops), returning the authoritative entity either way. So a
+stale device reconnecting cannot overwrite a newer edit made elsewhere — its
+write is *superseded*, a successful no-op that ordinary convergence cleans up.
+
+Three delivery outcomes, no others:
+
+- **applied** — proposal won; confirmed entity converges everywhere.
+- **superseded** — backend held something newer; slot dropped; server truth
+  repaints via the normal sync path. Silent by default.
+- **rejected** — backend invariant said no (thrown as a non-retriable error);
+  slot dropped, optimistic state rolls back, app notified.
+
+Transient failures (network, 5xx, timeout) are none of these: the slot stays
+and retries on an Effect `Schedule` backoff. Classification is throw-based —
+a tagged non-retriable error means rejected; everything else retries.
+
+### Presentation: TanStack's own optimism, no custom overlay
+
+A pending offline write **is** a live TanStack optimistic mutation. The
+mutation handler resolves only when the outbox delivers its entry and throws
+only on rejection — so TanStack's native rollback undoes rejected optimism,
+and `$synced` / `$origin` stay truthful for the whole offline window
+(`$synced: false` = genuinely not on the server yet). Consequences:
+
+- **Reload replay is "call the front door again."** On boot, each surviving
+  outbox entry re-invokes the same public operation — entity ops replay their
+  stored diffs, actions re-invoke by name with their persisted payload —
+  flagged via `metadata: { std: { replay: entryId } }` so the wrapper
+  re-attaches to the existing entry instead of enqueueing a duplicate.
+- **Closures never persist; only data does.** Entity updates store the
+  computed changes, not the updater function. Actions must be named and their
+  payloads schema-validated (eschema where possible, so queued payloads
+  migrate across app versions).
+- **Awaiting a write while offline blocks until delivery** (Firestore
+  semantics — document loudly). A separate durable acknowledgment answers
+  "is it safely queued" for callers who need to navigate away.
+
+### Configuration: offline is orthogonal to pacing
+
+Pacing smooths rapid edits in memory (*when* to send); offline makes intent
+durable (*what survives*). Sibling options, any combination:
+
+```typescript
+const tasks = std.collection({
+  schema: TaskSchema,
+  updatePacing: paceStrategy.debounce({ wait: 300 }), // optional, as today
+  offline: true, // or { retry, onDiscarded, ... }; instance-level defaults on createStdSync
+  onInsert, // unchanged signatures — invoked by the drain instead of directly
+  onUpdate,
+  onDelete,
+});
+```
+
+Eager (unpaced) writes still want durability, so nothing is restricted. Note:
+pacing currently intercepts only `pacedUpdate`; the offline interception must
+cover plain `insert` / `update` / `delete` too.
+
+### Actions: named, partitioned FIFO lanes
+
+```typescript
+const archiveProject = std.createOfflineAction({
+  name: 'archive-project',            // unique + stable: the routing address
+  payload: Schema.Struct({ projectId: Schema.String }),
+  onMutate: ({ projectId }) => {      // immediate optimistic application
+    projects.update(projectId, (d) => { d.archived = true; });
+  },
+  mutationFn: ({ projectId }, { idempotencyKey }) =>
+    api.archiveProject(projectId, { idempotencyKey }), // runs at drain turn
+  partition: ({ projectId }) => projectId, // omit = one default lane
+  onPartitionReject: 'halt',          // or 'discard' | 'continue'
+});
+
+const handle = archiveProject({ projectId: 'p1' });
+await handle.durable;   // safely queued
+await handle.done;      // executed on server; rejects → onMutate rolls back
+handle.cancel();        // 'cancelled' | 'in-flight' | 'not-found'
+```
+
+- Entries addressed by `(namespace, action name, partition key, seq)`.
+- Lanes are independent FIFO queues: parallel across lanes, strict order
+  within one, created lazily, GC'd when empty, with a lane-count warning.
+- Rejection policy per lane: `halt` parks the lane durably (companion API:
+  `std.offline.partition(key).pending() / resume() / discardAll()`),
+  `discard` drops the remainder and rolls back their optimism, `continue`
+  fails only that entry.
+- Duplicate action names throw at definition time. Entries whose name no
+  longer exists after a deploy are parked and reported via `onUnknownAction`.
+- Slots and lanes are independent; same-entity overlap is arbitrated by LWW.
+  Flows that need strict ordering live entirely inside one lane.
+
+### Storage, multi-tab, lifecycle
+
+- New stored entities in the **existing Sync Store StdTable** — durability
+  (memory / IndexedDB / SQLite) stays the platform's one choice.
+- **Any tab enqueues; only the leader drains.** New `OfflineDrain` Leadership
+  role: one lock per collection (entity lane), one per active action lane.
+  Per-entity serialization is the drainer's in-flight map, not a lock.
+- **In-flight is not in the slot**: the drainer claims a slot by clearing it;
+  edits during flight write a fresh slot; a landed flight resolves every
+  waiter at or below the generation it carried (correct under coalescing).
+- Completion is broadcast on the existing peer channel so a non-leader tab's
+  pending handler resolves; the store is the truth on boot.
+- The **version gate** also wipes outbox records, emitting a
+  discarded-count event. **`std.reset()`** wipes replicas, cursors, state,
+  and outbox for logout; the documented pattern is a user-scoped Std Sync
+  name so cross-user leakage is structurally impossible.
+- Status surface: `tasks.utils.outbox.pending() / size() / subscribe() /
+  cancel(id)`, `std.offline.size() / subscribe()`, per-row status derived
+  from outbox state.
+
+### Prior art
+
+`@tanstack/offline-transactions` (official, TanStack DB monorepo) validates
+the architecture and is deliberately mirrored in vocabulary
+(non-retriable-error classification, idempotency keys, unknown-handler hook)
+and mined for test scenarios. It is not adopted: no cross-transaction
+coalescing, one global FIFO (a stuck transaction blocks every entity),
+non-leader tabs do not persist offline writes, and it duplicates storage /
+election / retry / telemetry that std-toolkit owns in Effect-native form.
+See ADR 0005 for the full comparison.
+
+## Implementation phases
+
+Each phase ships and is testable independently.
+
+### Phase 1 — outbox core (isolated, no wiring)
+
+- `persistence/outbox-store/`: stored entities for slots
+  (`collection`, entity `key`, `kind`, encoded `value`, `proposedU`,
+  `attempts`, `enqueuedAt`), action entries
+  (`namespace`, `actionName`, `partitionKey`, `seq`, payload, idempotency
+  key, `attempts`), and lane status (`halted`).
+- `runtime/outbox/`: `put` (coalescing table), `remove`, `list`, `size`,
+  `subscribe`; per-entity generation counter and waiter registry; claim-by-
+  clear in-flight discipline; drain loop with Effect `Schedule` retry and
+  throw-based rejection classification.
+- `proposedU` minting (HLC-disciplined ULID) and client id minting rules in
+  `core`/`runtime`.
+- Tests against the Memory store: coalescing table, generation waiters,
+  outcome handling, claim/re-slot during flight.
+
+### Phase 2 — entity lane wiring
+
+- `composition/keyed-sync/mutations.ts`: behind the collection `offline`
+  option, handlers enqueue the slot first, stay pending until delivery,
+  throw on rejection; interception covers insert/update/delete and
+  `pacedUpdate`.
+- Drain worker registered under the `OfflineDrain` Leadership role (one per
+  collection); wakes on enqueue, boot, connectivity, retry schedule.
+- Browser platform: connectivity signal (`navigator.onLine` + events).
+- Boot replay: after collection ready, replay surviving slots as front-door
+  operations with the replay flag.
+- Flow tracing: outbox lane with enqueue/flight/outcome activities.
+- Tests: online behavior identical to today; reload mid-flight loses
+  nothing; superseded and rejected paths; multi-tab leader handoff.
+
+### Phase 3 — lifecycle and status
+
+- Version gate wipes outbox records + discarded-count event.
+- `std.reset()`; document the user-scoped namespace logout pattern.
+- Status APIs: `utils.outbox.*`, instance-level roll-up, per-row status;
+  `handle.durable` acknowledgment; cross-tab completion broadcast over the
+  peer channel.
+- `onDiscarded` / outbox events through the existing `onEvent` surface.
+
+### Phase 4 — offline actions
+
+- `createOfflineAction` module: action registry (duplicate names throw),
+  payload schemas, `onMutate` + `mutationFn`, handles
+  (`durable` / `done` / `cancel`), partitioned FIFO lanes with lazy workers
+  (one Leadership lock per active lane), `onPartitionReject` policies with
+  the halted-lane companion API, `onUnknownAction` parking, boot replay by
+  name, idempotency keys.
+- Tests: lane independence, in-lane ordering, halt/discard/continue,
+  rename/unknown-action parking, reload replay of queued actions.
+
+### Phase 5 — server recipe and docs
+
+- Documented backend pattern (with example) for the conditional apply:
+  db `transact` check on `_u`, return the authoritative entity on
+  supersession; future-bound validation of `proposedU`.
+- eschema payload guidance for actions; README/docs updates; sync stories
+  covering the full user journeys (fast edits offline → reload → reconnect;
+  two-device stale write; halted lane recovery).
+
+## Out of scope (deliberate)
+
+Field-level merge, CRDT collaborative editing, cross-tab visibility of
+*unsent* optimistic state, at-rest encryption, and a per-call
+`offline: false` escape hatch (revisit only if a real use case demands it).

--- a/std-toolkit/src/sync/docs/offline-plan.md
+++ b/std-toolkit/src/sync/docs/offline-plan.md
@@ -47,14 +47,40 @@ Slot coalescing rules:
 
 ### Conflicts: the newest *edit* wins, not the newest *arrival*
 
-Every slot carries `proposedU` — a `_u` ULID minted the moment the user edited,
-disciplined as a hybrid logical clock (never behind the newest `_u` this client
-has seen; server rejects far-future stamps). Entity ids are minted on the
-client so offline inserts have stable identity. The backend applies a slot
-conditionally: **apply iff `proposedU` is newer than the stored `_u`** (db
-`transact` check ops), returning the authoritative entity either way. So a
-stale device reconnecting cannot overwrite a newer edit made elsewhere — its
-write is *superseded*, a successful no-op that ordinary convergence cleans up.
+Every slot carries `proposedU` — a ULID minted the moment the user edited,
+disciplined as a hybrid logical clock (never behind the newest update stamp
+this client has seen). Entity ids are minted on the client so offline inserts
+have stable identity.
+
+**Critical: the proposal never becomes `_u`.** `_u` is also the cursor axis —
+strategies fetch "entities beyond cursor X" by `_u` — so writing an old
+edit-time stamp into `_u` would land the accepted write *behind* other
+clients' cursors, invisible to incremental sync forever. The roles split:
+
+- `_u` stays **server-minted at write time**. Every accepted write is ahead
+  of every cursor; sync visibility never depends on a client clock. Client
+  convergence keeps comparing `_u` alone — unchanged.
+- A new optional meta field, the **edit stamp `_p`**, records the winning
+  `proposedU`. The backend applies a slot conditionally: **apply iff
+  `proposedU` is newer than the stored `_p`** (db `transact` check ops),
+  writing fresh server `_u` + `_p = proposedU` on apply, and returning the
+  authoritative entity either way. So a stale device reconnecting cannot
+  overwrite a newer edit made elsewhere — its write is *superseded*, a
+  successful no-op that ordinary convergence cleans up.
+
+`proposedU` is **optional end to end**: a backend that ignores it stamps `_u`
+on arrival and skips the `_p` compare — arrival-order LWW, today's behavior,
+nothing breaks. Forwarding one field and using the conditional-apply helper
+upgrades to edit-time LWW.
+
+Clock drift is **accounted for, not solved**: sync visibility is immune by
+construction (`_u` is server time). Drift affects only conflict fairness
+between devices — a behind clock is defended by the HLC floor (never stamps
+behind what it has seen, so it cannot lose to itself on an uncontended
+entity), an ahead clock is bounded by a server tolerance on `proposedU`
+(minutes; beyond it the write is refused as malformed). Within tolerance an
+ahead clock wins conflicts unfairly for its skew — documented degradation,
+never a correctness failure.
 
 Three delivery outcomes, no others:
 
@@ -231,8 +257,10 @@ Each phase ships and is testable independently.
 ### Phase 5 — server recipe and docs
 
 - Documented backend pattern (with example) for the conditional apply:
-  db `transact` check on `_u`, return the authoritative entity on
-  supersession; future-bound validation of `proposedU`.
+  db `transact` check on the `_p` edit stamp (`proposedU > stored _p`),
+  writing fresh server-minted `_u` + `_p = proposedU` on apply, returning
+  the authoritative entity on supersession; future-bound validation of
+  `proposedU`; db support for writing `_p` alongside the server-minted `_u`.
 - eschema payload guidance for actions; README/docs updates; sync stories
   covering the full user journeys (fast edits offline → reload → reconnect;
   two-device stale write; halted lane recovery).
@@ -246,13 +274,16 @@ conventions), the existing workers (drain worker shape), and laymos layering.
 
 ### `proposedU` minting (HLC discipline)
 
-Keep a per-Std-Sync `lastSeenU` (max of: every `_u` accepted into any replica,
-and every `proposedU` this client minted; persist it in the Sync Store,
-updating opportunistically). Mint with `ulidx` monotonic factory seeded at
-`max(Date.now(), uTime(lastSeenU))`; monotonic mode already breaks same-ms
-ties. The server-side recipe (phase 5) rejects a `proposedU` more than a
-configured tolerance (default: 5 minutes) ahead of server time as a
-`rejected` outcome.
+Keep a per-Std-Sync `lastSeenStamp` (max of: every `_u` and every `_p`
+accepted into any replica, and every `proposedU` this client minted; persist
+it in the Sync Store, updating opportunistically). Mint with `ulidx`
+monotonic factory seeded at `max(Date.now(), uTime(lastSeenStamp))`;
+monotonic mode already breaks same-ms ties. The server-side recipe (phase 5)
+refuses a `proposedU` more than a configured tolerance (default: 5 minutes)
+ahead of server time as a `rejected` outcome. `proposedU` is compared only
+against the stored `_p` edit stamp — never written into or compared against
+`_u`, which remains server-minted (see "Conflicts" above). `_p` is a new
+optional Entity Meta field defined in `core` alongside `_s`/`_c`.
 
 ### Stored entities (same StdTable as `sync-store.ts`)
 


### PR DESCRIPTION
## Problem

Sync's read side is durable (replicas, cursors, strategy state survive reloads), but a write is only as durable as the tab it was made in: optimistic mutations live in TanStack DB memory until confirmed, so a reload, crash, or offline window silently loses the user's edit.

## What this adds

Two design documents, no code changes:

- **ADR 0005** (`std-toolkit/src/sync/docs/adr/0005-offline-writes-are-slots-and-named-actions.md`) — the decisions:
  - Entity-level offline writes are **per-entity outbox slots** (latest desired state or tombstone, coalesced on overwrite), not an operation diary — no chains, no cascading failures.
  - **Edit-time LWW**: client-minted ids and `proposedU` (HLC-disciplined ULID stamped at edit time); the backend applies conditionally via db `transact` (apply iff newer), yielding exactly three outcomes: applied / superseded / rejected.
  - **Presentation through TanStack's front door**: handlers stay pending until delivery, throw on rejection (native rollback), boot replay re-invokes public operations — `$synced`/`$origin` stay truthful, no custom overlay layer.
  - **Offline is orthogonal to pacing** (sibling collection option, any combination).
  - **`createOfflineAction`**: named, payload-schema'd, partitioned FIFO lanes with per-lane rejection policy (`halt`/`discard`/`continue`), handles (`durable`/`done`/`cancel`), `onUnknownAction` parking.
  - **One store, one election**: outbox records live in the existing Sync Store; any tab enqueues, only the leader drains (new `OfflineDrain` Leadership role); version gate and `reset()` cover the outbox.
  - Rationale for building in-toolkit instead of adopting `@tanstack/offline-transactions` (no cross-transaction coalescing, global FIFO, non-leader tabs don't persist), while mirroring its vocabulary and mining its test scenarios.

- **Implementation plan** (`std-toolkit/src/sync/docs/offline-plan.md`) — problem, solution in simple terms (coalescing table, conflict model, config surface, action API, storage/multi-tab/lifecycle), and five independently shippable phases: outbox core → entity lane wiring → lifecycle/status → offline actions → server recipe and docs.

Intended as the reference for the implementation work starting in a follow-up session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XacgYY1j7s2TZjfUTWHLZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XacgYY1j7s2TZjfUTWHLZ1)_